### PR TITLE
Run setup (migrate + boot)

### DIFF
--- a/logs/run-setup-2025-09-30.md
+++ b/logs/run-setup-2025-09-30.md
@@ -1,0 +1,45 @@
+# Run setup logs - 2025-09-30
+
+## pip install -r requirements.txt
+```
+Requirement already satisfied: Flask in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 1)) (3.1.2)
+Requirement already satisfied: Flask-JWT-Extended in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 2)) (4.7.1)
+Requirement already satisfied: Flask-Migrate in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 3)) (4.1.0)
+Requirement already satisfied: SQLAlchemy in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 4)) (2.0.43)
+Requirement already satisfied: python-dotenv in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 5)) (1.1.1)
+Requirement already satisfied: stripe in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 6)) (12.5.1)
+Requirement already satisfied: boto3 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 7)) (1.40.41)
+Requirement already satisfied: gunicorn in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 8)) (23.0.0)
+...
+```
+
+## flask db migrate -m "init schema" || true
+```
+INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
+INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
+ERROR [flask_migrate] Error: Target database is not up to date.
+```
+
+## flask db upgrade
+```
+INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
+INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> 6d6be07685c8, Create core tables.
+```
+
+## flask run --host=0.0.0.0 --port=5000
+```
+ * Serving Flask app 'app:create_app'
+ * Debug mode: off
+WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5000
+ * Running on http://127.0.0.1:5000
+Press CTRL+C to quit
+127.0.0.1 - - [30/Sep/2025 00:40:29] "GET /health HTTP/1.1" 200 -
+```
+
+## curl -sS http://127.0.0.1:5000/health
+```
+{"status":"ok"}
+```


### PR DESCRIPTION
## Summary
- add run setup log capturing the environment bootstrap commands and their outputs

## Testing
- `curl -sS http://127.0.0.1:5000/health`

## Console Logs
```
pip install -r requirements.txt
Requirement already satisfied: Flask in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 1)) (3.1.2)
Requirement already satisfied: Flask-JWT-Extended in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 2)) (4.7.1)
Requirement already satisfied: Flask-Migrate in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 3)) (4.1.0)
Requirement already satisfied: SQLAlchemy in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 4)) (2.0.43)
Requirement already satisfied: python-dotenv in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 5)) (1.1.1)
Requirement already satisfied: stripe in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 6)) (12.5.1)
Requirement already satisfied: boto3 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 7)) (1.40.41)
Requirement already satisfied: gunicorn in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements.txt (line 8)) (23.0.0)
...

flask db migrate -m "init schema" || true
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
ERROR [flask_migrate] Error: Target database is not up to date.

flask db upgrade
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 6d6be07685c8, Create core tables.

flask run --host=0.0.0.0 --port=5000
 * Serving Flask app 'app:create_app'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000
 * Running on http://127.0.0.1:5000
Press CTRL+C to quit
127.0.0.1 - - [30/Sep/2025 00:40:29] "GET /health HTTP/1.1" 200 -

curl -sS http://127.0.0.1:5000/health
{"status":"ok"}
```

------
https://chatgpt.com/codex/tasks/task_e_68db26c5cde08333ab8c21454b305ae9