### PR TITLE
CI: install pytest dependencies and run migrations before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
+      - name: Migrate DB and run tests
+        env:
+          SECRET_KEY: ci
+          JWT_SECRET_KEY: ci
+          DATABASE_URL: sqlite:///test.db
+          UPLOAD_DIR: workspace/uploads
+          FLASK_APP: app:create_app
+        run: |
+          mkdir -p workspace/uploads
+          flask db upgrade || (flask db init && flask db migrate -m "ci init" && flask db upgrade)
+          pytest -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- add development requirements file with pytest tooling
- update CI workflow to use Python 3.12, install dev deps, configure environment variables, and run migrations before tests

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68db2c1c73c48333be90df89ca8a49fc