### PR TITLE
feat: revamp visa document model

### DIFF
--- a/migrations/versions/d4d19a25492d_update_visa_document_model.py
+++ b/migrations/versions/d4d19a25492d_update_visa_document_model.py
@@ -1,0 +1,91 @@
+"""Update visa document model.
+
+Revision ID: d4d19a25492d
+Revises: 1c2a8b2d5f0a
+Create Date: 2025-09-30 04:08:13.758484
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d4d19a25492d"
+down_revision = "1c2a8b2d5f0a"
+branch_labels = None
+depends_on = None
+
+
+VISA_DOCUMENT_STATUS_NAME = "visa_document_status"
+
+
+def upgrade():
+    """Apply the visa document schema changes."""
+
+    op.drop_table("visa_documents")
+    op.execute(f"DROP TYPE IF EXISTS {VISA_DOCUMENT_STATUS_NAME}")
+    op.execute("DROP TYPE IF EXISTS visa_document_type")
+
+    op.create_table(
+        "visa_documents",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("file_path", sa.String(length=512), nullable=False),
+        sa.Column("file_type", sa.String(length=128), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "approved",
+                "rejected",
+                name=VISA_DOCUMENT_STATUS_NAME,
+            ),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("reviewer_id", sa.Integer(), nullable=True),
+        sa.Column("review_note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_visa_documents_user_id"),
+        "visa_documents",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    """Revert the visa document schema changes."""
+
+    op.drop_index(op.f("ix_visa_documents_user_id"), table_name="visa_documents")
+    op.drop_table("visa_documents")
+    op.execute(f"DROP TYPE IF EXISTS {VISA_DOCUMENT_STATUS_NAME}")
+
+    op.create_table(
+        "visa_documents",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "doc_type",
+            sa.Enum("passport", "j1_visa", name="visa_document_type"),
+            nullable=False,
+        ),
+        sa.Column("file_url", sa.String(length=512), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "approved", "denied", name=VISA_DOCUMENT_STATUS_NAME),
+            nullable=False,
+        ),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )

--- a/models/visa_document.py
+++ b/models/visa_document.py
@@ -1,44 +1,64 @@
-"""Visa document model."""
+"""VisaDocument model definition."""
 
 from datetime import datetime
 
 from . import db
 
 
-DOC_TYPES = ("passport", "j1_visa")
-VISA_STATUSES = ("pending", "approved", "denied")
+VISA_DOCUMENT_STATUSES = ("pending", "approved", "rejected")
 
 
 class VisaDocument(db.Model):
-    """Stores uploaded visa documentation for verification."""
+    """Represents an uploaded visa document awaiting review."""
 
     __tablename__ = "visa_documents"
 
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-    doc_type = db.Column(db.Enum(*DOC_TYPES, name="visa_document_type"), nullable=False)
-    file_url = db.Column(db.String(512), nullable=False)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    filename = db.Column(db.String(255), nullable=False)
+    file_path = db.Column(db.String(512), nullable=False)
+    file_type = db.Column(db.String(128), nullable=False)
     status = db.Column(
-        db.Enum(*VISA_STATUSES, name="visa_document_status"),
+        db.Enum(*VISA_DOCUMENT_STATUSES, name="visa_document_status"),
         nullable=False,
         default="pending",
+        server_default=db.text("'pending'"),
     )
-    notes = db.Column(db.Text, nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    reviewer_id = db.Column(db.Integer, nullable=True)
+    review_note = db.Column(db.Text, nullable=True)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=db.func.now(),
+    )
 
     user = db.relationship(
-        "User", backref=db.backref("visa_documents", lazy="dynamic")
+        "User",
+        backref=db.backref("visa_documents", lazy="dynamic"),
     )
 
+    def __repr__(self) -> str:
+        return (
+            f"<VisaDocument id={self.id} user_id={self.user_id} status={self.status}>"
+        )
+
     def to_dict(self) -> dict:
-        """Serialize the document."""
+        """Serialize the visa document into a dictionary."""
 
         return {
             "id": self.id,
             "user_id": self.user_id,
-            "doc_type": self.doc_type,
-            "file_url": self.file_url,
+            "filename": self.filename,
+            "file_path": self.file_path,
+            "file_type": self.file_type,
             "status": self.status,
-            "notes": self.notes,
+            "reviewer_id": self.reviewer_id,
+            "review_note": self.review_note,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }


### PR DESCRIPTION
## Summary
- replace the visa document SQLAlchemy model with the new metadata fields and helpers
- refresh verification routes to use the updated schema and track reviewers
- add an Alembic migration to rebuild the visa_documents table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5715af9c8333b684b2027a7ec494