### PR TITLE
Add storage abstractions for uploads

### DIFF
--- a/storage/abstract_storage.py
+++ b/storage/abstract_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import IO
+from typing import IO, BinaryIO
 
 
 class AbstractStorage(ABC):
@@ -11,6 +11,12 @@ class AbstractStorage(ABC):
 
     @abstractmethod
     def save(self, file_obj: IO[bytes], filename: str) -> str:
-        """Persist a file and return the stored path."""
+        """Persist a file and return the stored (relative) path."""
 
-        raise NotImplementedError
+    @abstractmethod
+    def exists(self, path: str) -> bool:
+        """Return whether the given relative path exists in storage."""
+
+    @abstractmethod
+    def open(self, path: str, mode: str = "rb") -> BinaryIO:
+        """Open a stored file and return the file object."""

--- a/storage/local_storage.py
+++ b/storage/local_storage.py
@@ -2,41 +2,46 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
-from typing import IO
-from uuid import uuid4
+from typing import IO, BinaryIO
 
-from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
+
+from config import Config
 
 from .abstract_storage import AbstractStorage
 
 
 class LocalStorage(AbstractStorage):
-    """Persist files to the local filesystem."""
+    """Persist files to the local filesystem under the configured upload directory."""
 
-    def __init__(self, base_directory: str):
-        self.base_directory = Path(base_directory)
-        self.base_directory.mkdir(parents=True, exist_ok=True)
+    def __init__(self, upload_dir: str | None = None):
+        self.base_directory = Path(upload_dir or Config.UPLOAD_DIR)
+        os.makedirs(self.base_directory, exist_ok=True)
 
-    def save(self, file_obj: IO[bytes] | FileStorage, filename: str) -> str:
-        """Save a file to the upload directory and return the path."""
+    def save(self, file_obj: IO[bytes], filename: str) -> str:
+        """Save a file and return the relative path within the upload directory."""
 
-        safe_name = secure_filename(filename) or f"upload_{uuid4().hex}"
+        safe_name = secure_filename(filename)
+        if not safe_name:
+            raise ValueError("Filename must contain at least one valid character.")
+
         destination = self.base_directory / safe_name
-
-        stem = destination.stem
-        suffix = destination.suffix
-        counter = 1
-        while destination.exists():
-            destination = self.base_directory / f"{stem}_{counter}{suffix}"
-            counter += 1
-
-        if isinstance(file_obj, FileStorage):
-            file_obj.save(destination)
-        else:  # pragma: no cover - fallback for non FileStorage objects
+        if hasattr(file_obj, "save"):
+            file_obj.save(destination)  # type: ignore[arg-type]
+        else:
             with open(destination, "wb") as output:
-                data = file_obj.read()
-                output.write(data)
+                output.write(file_obj.read())
 
-        return str(destination)
+        return str(destination.relative_to(self.base_directory))
+
+    def exists(self, path: str) -> bool:
+        """Return True if the given relative path exists within the upload directory."""
+
+        return (self.base_directory / path).exists()
+
+    def open(self, path: str, mode: str = "rb") -> BinaryIO:
+        """Open a stored file using the provided mode."""
+
+        return open(self.base_directory / path, mode)


### PR DESCRIPTION
## Summary
- define an abstract storage interface with save, exists, and open contracts
- implement local storage that persists files under the configured upload directory using secure filenames

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5a8bcc8c83339fda7bde36e354f1