### PR TITLE
feat: verification routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,7 @@ from config import Config
 from models import db
 from routes.auth import auth_bp
 from routes.listings import listings_bp
-from routes.verify import admin_bp, verify_bp
+from routes.verify import verify_bp
 
 # Billing routes may be optional; import safely
 try:
@@ -192,7 +192,6 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     # Blueprints
     app.register_blueprint(verify_bp, url_prefix="/verify")
-    app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(listings_bp, url_prefix="/listings")
     if billing_bp:  # only if billing module exists
         app.register_blueprint(billing_bp, url_prefix="/billing")

--- a/migrations/versions/8a2f5e85a0e4_add_verification_status_fields.py
+++ b/migrations/versions/8a2f5e85a0e4_add_verification_status_fields.py
@@ -1,0 +1,69 @@
+"""Add verification status tracking to users and visa documents."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8a2f5e85a0e4"
+down_revision = "d4d19a25492d"
+branch_labels = None
+depends_on = None
+
+
+VERIFICATION_STATUS_ENUM = "verification_status"
+
+
+def upgrade() -> None:
+    """Apply the verification status schema changes."""
+
+    verification_status = sa.Enum(
+        "unverified",
+        "pending",
+        "approved",
+        "rejected",
+        name=VERIFICATION_STATUS_ENUM,
+    )
+    verification_status.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "verification_status",
+            verification_status,
+            nullable=False,
+            server_default=sa.text("'unverified'"),
+        ),
+    )
+    op.execute(
+        "UPDATE users SET verification_status='approved' WHERE is_verified = 1"
+    )
+    op.alter_column("users", "verification_status", server_default=None)
+
+    op.add_column(
+        "visa_documents",
+        sa.Column(
+            "waiver_acknowledged",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.execute(
+        "UPDATE visa_documents SET waiver_acknowledged=0 WHERE waiver_acknowledged IS NULL"
+    )
+    op.alter_column(
+        "visa_documents",
+        "waiver_acknowledged",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    """Revert the verification status schema changes."""
+
+    op.drop_column("visa_documents", "waiver_acknowledged")
+
+    op.drop_column("users", "verification_status")
+    verification_status = sa.Enum(name=VERIFICATION_STATUS_ENUM)
+    verification_status.drop(op.get_bind(), checkfirst=True)

--- a/models/user.py
+++ b/models/user.py
@@ -7,6 +7,9 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from . import db
 
 
+VERIFICATION_STATUSES = ("unverified", "pending", "approved", "rejected")
+
+
 class User(db.Model):
     """Represents a platform user."""
 
@@ -17,6 +20,12 @@ class User(db.Model):
     password_hash = db.Column(db.String(255), nullable=False)
     role = db.Column(db.String(32), nullable=False, default="worker")
     is_verified = db.Column(db.Boolean, nullable=False, default=False)
+    verification_status = db.Column(
+        db.Enum(*VERIFICATION_STATUSES, name="verification_status"),
+        nullable=False,
+        default="unverified",
+        server_default=db.text("'unverified'"),
+    )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     subscription = db.relationship(
         "EmployerSubscription",

--- a/models/visa_document.py
+++ b/models/visa_document.py
@@ -31,6 +31,12 @@ class VisaDocument(db.Model):
     )
     reviewer_id = db.Column(db.Integer, nullable=True)
     review_note = db.Column(db.Text, nullable=True)
+    waiver_acknowledged = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        server_default=db.text("0"),
+    )
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -60,5 +66,6 @@ class VisaDocument(db.Model):
             "status": self.status,
             "reviewer_id": self.reviewer_id,
             "review_note": self.review_note,
+            "waiver_acknowledged": self.waiver_acknowledged,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }

--- a/scripts/bootstrap_demo.py
+++ b/scripts/bootstrap_demo.py
@@ -40,12 +40,18 @@ def get_or_create_user(email: str, password: str, role: str) -> User:
 
     user = User.query.filter_by(email=email).first()
     if user is None:
-        user = User(email=email, role=role, is_verified=True)
+        user = User(
+            email=email,
+            role=role,
+            is_verified=True,
+            verification_status="approved",
+        )
         user.set_password(password)
         db.session.add(user)
     else:
         user.role = role
         user.is_verified = True
+        user.verification_status = "approved"
         user.set_password(password)
     return user
 

--- a/scripts/seed_admin.py
+++ b/scripts/seed_admin.py
@@ -13,13 +13,19 @@ def main() -> None:
     with app.app_context():
         admin = User.query.filter_by(email=ADMIN_EMAIL).first()
         if admin is None:
-            admin = User(email=ADMIN_EMAIL, role="admin", is_verified=True)
+            admin = User(
+                email=ADMIN_EMAIL,
+                role="admin",
+                is_verified=True,
+                verification_status="approved",
+            )
             admin.set_password(ADMIN_PASSWORD)
             db.session.add(admin)
             action = "created"
         else:
             admin.role = "admin"
             admin.is_verified = True
+            admin.verification_status = "approved"
             admin.set_password(ADMIN_PASSWORD)
             action = "updated"
         db.session.commit()

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -10,15 +10,28 @@ from models.listing import Listing
 from models.user import User
 
 
-def get_or_create_user(email: str, role: str, password: str, is_verified: bool = False) -> User:
+def get_or_create_user(
+    email: str,
+    role: str,
+    password: str,
+    is_verified: bool = False,
+) -> User:
+    status = "approved" if is_verified else "unverified"
     user = User.query.filter_by(email=email).first()
     if user is None:
-        user = User(email=email, role=role, is_verified=is_verified)
+        user = User(
+            email=email,
+            role=role,
+            is_verified=is_verified,
+            verification_status=status,
+        )
         user.set_password(password)
         db.session.add(user)
     else:
         user.role = role
-        user.is_verified = is_verified if role != "admin" else user.is_verified
+        if role != "admin":
+            user.is_verified = is_verified
+            user.verification_status = status
         user.set_password(password)
     return user
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -21,6 +21,6 @@ def test_health_endpoint_returns_ok(client, tmp_path):
 def test_blueprints_registered(app):
     """Application factory should register expected blueprints."""
     bps = set(app.blueprints.keys())
-    required = {"auth", "verify", "admin_verify", "listings"}
+    required = {"auth", "verify", "listings"}
     assert required.issubset(bps)
     # billing is optional; do not require it for tests

--- a/tests/test_verify_routes.py
+++ b/tests/test_verify_routes.py
@@ -1,0 +1,250 @@
+"""Tests for verification upload and admin review routes."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from flask_jwt_extended import create_access_token
+
+from models import db
+from models.user import User
+from models.visa_document import VisaDocument
+
+
+def _auth_headers(app, user_id: int) -> dict[str, str]:
+    with app.app_context():
+        token = create_access_token(identity=str(user_id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_user(email: str, role: str = "worker") -> User:
+    user = User(email=email, password_hash="hash", role=role)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_upload_document_creates_pending_record(app, client):
+    """Uploading a document stores the file and marks the user pending."""
+
+    with app.app_context():
+        user = _create_user("worker@example.com")
+        user_id = user.id
+
+    data = {
+        "document": (BytesIO(b"PDF data"), "visa.pdf"),
+        "waiver": "true",
+    }
+
+    response = client.post(
+        "/verify/upload",
+        data=data,
+        headers=_auth_headers(app, user_id),
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["status"] == "pending"
+
+    with app.app_context():
+        refreshed_user = User.query.get(user_id)
+        document = VisaDocument.query.get(payload["id"])
+
+    assert refreshed_user.verification_status == "pending"
+    assert refreshed_user.is_verified is False
+    assert document is not None
+    assert document.waiver_acknowledged is True
+    stored_file = Path(app.config["UPLOAD_DIR"]) / document.file_path
+    assert stored_file.exists()
+
+
+def test_status_endpoint_returns_latest_document(app, client):
+    """Status endpoint includes user status and latest document metadata."""
+
+    with app.app_context():
+        user = _create_user("status@example.com")
+        first = VisaDocument(
+            user_id=user.id,
+            filename="first.pdf",
+            file_path="first.pdf",
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=True,
+        )
+        db.session.add(first)
+        db.session.commit()
+
+        second = VisaDocument(
+            user_id=user.id,
+            filename="second.pdf",
+            file_path="second.pdf",
+            file_type="application/pdf",
+            status="approved",
+            waiver_acknowledged=True,
+        )
+        user.verification_status = "approved"
+        user.is_verified = True
+        db.session.add(second)
+        db.session.commit()
+        user_id = user.id
+
+    response = client.get(
+        "/verify/status",
+        headers=_auth_headers(app, user_id),
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["verification_status"] == "approved"
+    assert payload["latest_document"]["filename"] == "second.pdf"
+
+
+def test_admin_can_download_document(app, client):
+    """Admins can download stored documents."""
+
+    with app.app_context():
+        admin = _create_user("admin@example.com", role="admin")
+        admin.is_verified = True
+        admin.verification_status = "approved"
+        worker = _create_user("download@example.com")
+        rel_path = "stored.pdf"
+        stored = Path(app.config["UPLOAD_DIR"]) / rel_path
+        stored.parent.mkdir(parents=True, exist_ok=True)
+        stored.write_bytes(b"document-body")
+        document = VisaDocument(
+            user_id=worker.id,
+            filename="stored.pdf",
+            file_path=rel_path,
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=True,
+        )
+        db.session.add(document)
+        db.session.commit()
+        admin_id = admin.id
+        document_id = document.id
+
+    response = client.get(
+        f"/verify/doc/{document_id}",
+        headers=_auth_headers(app, admin_id),
+    )
+    assert response.status_code == 200
+    assert response.data == b"document-body"
+
+
+def test_admin_approve_updates_user_status(app, client):
+    """Approving a document updates both the document and user status."""
+
+    with app.app_context():
+        admin = _create_user("approver@example.com", role="admin")
+        admin.is_verified = True
+        admin.verification_status = "approved"
+        worker = _create_user("pending@example.com")
+        document = VisaDocument(
+            user_id=worker.id,
+            filename="pending.pdf",
+            file_path="pending.pdf",
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+        admin_id = admin.id
+        worker_id = worker.id
+        document_id = document.id
+
+    response = client.post(
+        f"/verify/{document_id}/approve",
+        headers=_auth_headers(app, admin_id),
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "approved"
+    assert payload["verification_status"] == "approved"
+
+    with app.app_context():
+        refreshed_document = VisaDocument.query.get(document_id)
+        refreshed_user = User.query.get(worker_id)
+    assert refreshed_document.status == "approved"
+    assert refreshed_document.reviewer_id == admin.id
+    assert refreshed_user.is_verified is True
+    assert refreshed_user.verification_status == "approved"
+
+
+def test_admin_reject_updates_note_and_status(app, client):
+    """Rejecting a document stores a note and marks the user rejected."""
+
+    with app.app_context():
+        admin = _create_user("rejector@example.com", role="admin")
+        admin.is_verified = True
+        admin.verification_status = "approved"
+        worker = _create_user("reject@example.com")
+        document = VisaDocument(
+            user_id=worker.id,
+            filename="reject.pdf",
+            file_path="reject.pdf",
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=True,
+        )
+        db.session.add(document)
+        db.session.commit()
+        admin_id = admin.id
+        worker_id = worker.id
+        document_id = document.id
+
+    response = client.post(
+        f"/verify/{document_id}/reject",
+        json={"review_note": "Missing signature"},
+        headers=_auth_headers(app, admin_id),
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "rejected"
+    assert payload["review_note"] == "Missing signature"
+
+    with app.app_context():
+        refreshed_document = VisaDocument.query.get(document_id)
+        refreshed_user = User.query.get(worker_id)
+    assert refreshed_document.status == "rejected"
+    assert refreshed_document.review_note == "Missing signature"
+    assert refreshed_document.reviewer_id == admin.id
+    assert refreshed_user.verification_status == "rejected"
+    assert refreshed_user.is_verified is False
+
+
+def test_non_admin_cannot_access_admin_routes(app, client):
+    """Workers cannot access admin-only verification routes."""
+
+    with app.app_context():
+        worker = _create_user("noadmin@example.com")
+        document = VisaDocument(
+            user_id=worker.id,
+            filename="doc.pdf",
+            file_path="doc.pdf",
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+        worker_id = worker.id
+        document_id = document.id
+
+    response_doc = client.get(
+        f"/verify/doc/{document_id}",
+        headers=_auth_headers(app, worker_id),
+    )
+    response_approve = client.post(
+        f"/verify/{document_id}/approve",
+        headers=_auth_headers(app, worker_id),
+    )
+    response_reject = client.post(
+        f"/verify/{document_id}/reject",
+        headers=_auth_headers(app, worker_id),
+    )
+
+    assert response_doc.status_code == 403
+    assert response_approve.status_code == 403
+    assert response_reject.status_code == 403


### PR DESCRIPTION
## Summary
- replace the verification blueprint with upload, status, download, approve, and reject endpoints that enforce file restrictions, track waiver acknowledgement, and update user verification state
- add verification_status tracking on users plus waiver flags on visa documents with a migration and seed script updates
- add endpoint coverage tests for uploads and admin workflows and update application factory expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5bbacf908333951b4a3512cc8579