### PR TITLE
feat: user verification fields

### DIFF
--- a/migrations/versions/1b5a52d73d61_update_user_verification_fields.py
+++ b/migrations/versions/1b5a52d73d61_update_user_verification_fields.py
@@ -1,0 +1,125 @@
+"""Switch user verification status to string and add active flag."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1b5a52d73d61"
+down_revision = "8a2f5e85a0e4"
+branch_labels = None
+depends_on = None
+
+
+VERIFICATION_STATUS_ENUM = "verification_status"
+VERIFICATION_STATUS_VALUES = (
+    "unverified",
+    "pending",
+    "approved",
+    "rejected",
+)
+
+
+def upgrade() -> None:
+    """Apply the verification status and activation updates."""
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "verification_status_tmp",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'unverified'"),
+        ),
+    )
+    op.execute("UPDATE users SET verification_status_tmp = verification_status")
+    op.alter_column(
+        "users",
+        "verification_status_tmp",
+        server_default=None,
+        existing_type=sa.String(length=32),
+    )
+
+    op.drop_column("users", "verification_status")
+    op.alter_column(
+        "users",
+        "verification_status_tmp",
+        new_column_name="verification_status",
+        existing_type=sa.String(length=32),
+    )
+    op.alter_column(
+        "users",
+        "verification_status",
+        server_default=None,
+        existing_type=sa.String(length=32),
+    )
+
+    verification_status_enum = sa.Enum(name=VERIFICATION_STATUS_ENUM)
+    verification_status_enum.drop(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+    users = sa.table("users", sa.column("is_active", sa.Boolean()))
+    op.execute(users.update().where(users.c.is_active.is_(None)).values(is_active=True))
+
+    op.alter_column(
+        "users",
+        "is_active",
+        server_default=None,
+        existing_type=sa.Boolean(),
+    )
+
+
+def downgrade() -> None:
+    """Revert the verification status and activation updates."""
+
+    op.drop_column("users", "is_active")
+
+    verification_status_enum = sa.Enum(
+        *VERIFICATION_STATUS_VALUES, name=VERIFICATION_STATUS_ENUM
+    )
+    verification_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "verification_status_old",
+            verification_status_enum,
+            nullable=False,
+            server_default=sa.text("'unverified'"),
+        ),
+    )
+
+    op.execute(
+        """
+        UPDATE users
+        SET verification_status_old = CASE
+            WHEN verification_status IN ('unverified', 'pending', 'approved', 'rejected')
+                THEN verification_status
+            ELSE 'unverified'
+        END
+        """
+    )
+
+    op.alter_column(
+        "users",
+        "verification_status_old",
+        server_default=None,
+        existing_type=verification_status_enum,
+    )
+
+    op.drop_column("users", "verification_status")
+    op.alter_column(
+        "users",
+        "verification_status_old",
+        new_column_name="verification_status",
+        existing_type=verification_status_enum,
+    )

--- a/models/user.py
+++ b/models/user.py
@@ -1,6 +1,7 @@
 """User model definition."""
 
 from datetime import datetime
+from typing import Optional
 
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -21,10 +22,16 @@ class User(db.Model):
     role = db.Column(db.String(32), nullable=False, default="worker")
     is_verified = db.Column(db.Boolean, nullable=False, default=False)
     verification_status = db.Column(
-        db.Enum(*VERIFICATION_STATUSES, name="verification_status"),
+        db.String(32),
         nullable=False,
         default="unverified",
         server_default=db.text("'unverified'"),
+    )
+    is_active = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        server_default=db.text("true"),
     )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     subscription = db.relationship(
@@ -43,6 +50,18 @@ class User(db.Model):
         """Verify a password against the stored hash."""
 
         return check_password_hash(self.password_hash, password)
+
+    def mark_verified(self) -> None:
+        """Mark the user as verified and approved."""
+
+        self.is_verified = True
+        self.verification_status = "approved"
+
+    def mark_unverified(self, note: Optional[str] = None) -> None:
+        """Mark the user as unverified with an optional note."""
+
+        self.is_verified = False
+        self.verification_status = note or "unverified"
 
     def __repr__(self) -> str:  # pragma: no cover - debugging helper
         return f"<User {self.email}>"

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -1,0 +1,39 @@
+"""Tests for the User model helpers."""
+
+from models import db
+from models.user import User
+
+
+def test_user_verification_helpers(app):
+    """Ensure helper methods toggle verification state as expected."""
+
+    with app.app_context():
+        user = User(email="helper@example.com", role="worker")
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.commit()
+
+        assert user.is_active is True
+        assert user.verification_status == "unverified"
+        assert user.is_verified is False
+
+        user.mark_verified()
+        db.session.commit()
+        db.session.refresh(user)
+
+        assert user.is_verified is True
+        assert user.verification_status == "approved"
+
+        note = "awaiting documents"
+        user.mark_unverified(note=note)
+        db.session.commit()
+        db.session.refresh(user)
+
+        assert user.is_verified is False
+        assert user.verification_status == note
+
+        user.mark_unverified()
+        db.session.commit()
+        db.session.refresh(user)
+
+        assert user.verification_status == "unverified"


### PR DESCRIPTION
## Summary
- switch the user verification status column to a string field and introduce an active flag
- add helper methods to toggle verification along with coverage in a dedicated test
- provide an Alembic migration to convert existing data to the new schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5e9fc37c8333b207baa83b55bdf7