### PR TITLE
config: add upload settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 
 class Config:
-    """Base configuration for the Flask application."""
+    """Base configuration for the Flask application.
+
+    Environment variables:
+        MAX_UPLOAD_SIZE: Maximum upload size in bytes (default 10 MB).
+        ALLOWED_UPLOAD_TYPES: Comma-separated list of allowed MIME types for uploads.
+    """
 
     # Core
     SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
@@ -14,6 +19,10 @@ class Config:
     SQLALCHEMY_DATABASE_URI = DATABASE_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_DIR = os.getenv("UPLOAD_DIR", str(Path("workspace") / "uploads"))
+    MAX_UPLOAD_SIZE = int(os.getenv("MAX_UPLOAD_SIZE", 10 * 1024 * 1024))
+    ALLOWED_UPLOAD_TYPES = os.getenv(
+        "ALLOWED_UPLOAD_TYPES", "image/jpeg,image/png,application/pdf"
+    ).split(",")
 
     # CORS
     _raw_origins = os.getenv("ORIGINS", "*")


### PR DESCRIPTION
## Summary
- document upload-related environment variables in the base configuration
- add support for MAX_UPLOAD_SIZE and ALLOWED_UPLOAD_TYPES environment variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5eba79a083339ade0104e945f4dc