### PR TITLE
Handle MIME-configured verification upload extensions

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,8 @@ class Config:
 
     Environment variables:
         MAX_UPLOAD_SIZE: Maximum upload size in bytes (default 10 MB).
-        ALLOWED_UPLOAD_TYPES: Comma-separated list of allowed MIME types for uploads.
+        ALLOWED_UPLOAD_TYPES: Comma-separated list of allowed MIME types or file
+            extensions for uploads.
     """
 
     # Core

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -75,11 +75,23 @@ def _allowed_extensions() -> set[str]:
         values: Iterable[str] = configured.split(",")
     else:
         values = configured
-    normalized = {
-        item.strip().lower().lstrip(".")
-        for item in values
-        if isinstance(item, str) and item.strip()
-    }
+
+    normalized: set[str] = set()
+    for raw in values:
+        if not isinstance(raw, str):
+            continue
+
+        item = raw.strip().lower()
+        if not item:
+            continue
+
+        if "/" in item and not item.startswith("."):
+            item = item.rsplit("/", 1)[-1]
+
+        item = item.lstrip(".")
+        if item:
+            normalized.add(item)
+
     if not normalized:
         return set(ALLOWED_EXTENSIONS_DEFAULT)
     if "jpeg" in normalized:


### PR DESCRIPTION
## Summary
- normalize configured upload types so MIME-type values are accepted when validating verification documents
- document that ALLOWED_UPLOAD_TYPES supports MIME types or extensions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df431e1fac8333a5464da7fd36f2a6