### PR TITLE
Refactor verify admin routes to canonical /admin namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # J1hub
-The j1 app that will be popular in the dells 
+
+Backend API for authentication, visa verification workflows, listings, and billing support.
+
+## Verification API (OpenAPI-style endpoint table)
+
+All endpoints require `Authorization: Bearer <JWT>`.
+
+| Method | Path | Role | Request payload | Response |
+|---|---|---|---|---|
+| `POST` | `/verify/upload` | Worker | `multipart/form-data` with `document=<file>` and `waiver=<bool>` | `201` with `{ "id": <int>, "status": "pending" }` |
+| `GET` | `/verify/status` | Worker | None | `200` with `{ "verification_status": "pending\|approved\|rejected", "latest_document": {...}\|null }` |
+| `GET` | `/verify/doc/{id}` | Admin | None | `200` file download |
+| `GET` | `/admin/verify/pending` | Admin | None | `200` list of pending documents |
+| `POST` | `/admin/verify/{id}/approve` | Admin | None | `200` with approved document/user status |
+| `POST` | `/admin/verify/{id}/reject` | Admin | Optional JSON body `{ "review_note": "..." }` | `200` with rejected document/user status |
+
+### Deprecated legacy aliases
+
+These aliases are still enabled temporarily for backward compatibility and return a deprecation `Warning` response header:
+
+- `GET /verify/pending`
+- `POST /verify/{id}/approve`
+- `POST /verify/{id}/reject`
+
+Use the `/admin/verify/*` namespace for all admin verification actions.

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -21,6 +21,11 @@ from utils.request_validation import parse_json_request
 
 verify_bp = Blueprint("verify", __name__)
 
+DEPRECATION_WARNING = (
+    '299 - "Legacy /verify admin endpoints are deprecated; '
+    'use /admin/verify/* instead."'
+)
+
 MAX_UPLOAD_SIZE_DEFAULT = 10 * 1024 * 1024  # 10 MB
 ALLOWED_EXTENSIONS_DEFAULT = {"jpeg", "jpg", "png", "pdf"}
 
@@ -75,11 +80,16 @@ def _allowed_extensions() -> set[str]:
         values: Iterable[str] = configured.split(",")
     else:
         values = configured
-    normalized = {
-        item.strip().lower().lstrip(".")
-        for item in values
-        if isinstance(item, str) and item.strip()
-    }
+    normalized: set[str] = set()
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        cleaned = item.strip().lower()
+        if not cleaned:
+            continue
+        if "/" in cleaned:
+            cleaned = cleaned.rsplit("/", 1)[-1]
+        normalized.add(cleaned.lstrip("."))
     if not normalized:
         return set(ALLOWED_EXTENSIONS_DEFAULT)
     if "jpeg" in normalized:
@@ -224,7 +234,12 @@ def list_pending_documents() -> ResponseReturnValue:
         .all()
     )
 
-    return jsonify([_serialize_pending_document(document) for document in pending_documents])
+    response = jsonify([
+        _serialize_pending_document(document) for document in pending_documents
+    ])
+    if request.path == "/verify/pending":
+        response.headers["Warning"] = DEPRECATION_WARNING
+    return response
 
 
 @verify_bp.record_once
@@ -235,6 +250,24 @@ def _register_admin_routes(state) -> None:  # pragma: no cover - registration ho
         view_func=jwt_required()(list_pending_documents),
         methods=["GET"],
         endpoint="verify.list_pending_documents",
+    )
+    app.add_url_rule(
+        "/verify/pending",
+        view_func=jwt_required()(list_pending_documents),
+        methods=["GET"],
+        endpoint="verify.list_pending_documents_legacy",
+    )
+    app.add_url_rule(
+        "/admin/verify/<int:document_id>/approve",
+        view_func=jwt_required()(approve_document),
+        methods=["POST"],
+        endpoint="verify.approve_document_admin",
+    )
+    app.add_url_rule(
+        "/admin/verify/<int:document_id>/reject",
+        view_func=jwt_required()(reject_document),
+        methods=["POST"],
+        endpoint="verify.reject_document_admin",
     )
 
 
@@ -253,13 +286,16 @@ def approve_document(document_id: int):
 
     db.session.commit()
 
-    return jsonify(
+    response = jsonify(
         {
             "id": document.id,
             "status": document.status,
             "verification_status": document.user.verification_status,
         }
     )
+    if request.path.startswith("/verify/"):
+        response.headers["Warning"] = DEPRECATION_WARNING
+    return response
 
 
 @verify_bp.route("/<int:document_id>/reject", methods=["POST"])
@@ -284,7 +320,7 @@ def reject_document(document_id: int):
 
     db.session.commit()
 
-    return jsonify(
+    response = jsonify(
         {
             "id": document.id,
             "status": document.status,
@@ -292,3 +328,6 @@ def reject_document(document_id: int):
             "review_note": document.review_note,
         }
     )
+    if request.path.startswith("/verify/"):
+        response.headers["Warning"] = DEPRECATION_WARNING
+    return response

--- a/tests/curl_examples.md
+++ b/tests/curl_examples.md
@@ -14,8 +14,8 @@ export WORKER_TOKEN="<worker access token>"
 ```bash
 curl -X POST "$BASE_URL/verify/upload" \
   -H "Authorization: Bearer $WORKER_TOKEN" \
-  -F "doc_type=passport" \
-  -F "file=@/path/to/passport.pdf"
+  -F "document=@/path/to/passport.pdf" \
+  -F "waiver=true"
 ```
 
 ## Check Verification Status
@@ -36,18 +36,23 @@ curl -X GET "$BASE_URL/admin/verify/pending" \
 
 ```bash
 curl -X POST "$BASE_URL/admin/verify/1/approve" \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"notes": "Looks good"}'
+  -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-## Admin Deny Document
+## Admin Reject Document
 
 ```bash
-curl -X POST "$BASE_URL/admin/verify/1/deny" \
+curl -X POST "$BASE_URL/admin/verify/1/reject" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"notes": "Please upload a clearer copy"}'
+  -d '{"review_note": "Please upload a clearer copy"}'
+```
+
+## Legacy Admin Alias (Deprecated)
+
+```bash
+curl -X GET "$BASE_URL/verify/pending" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
 ## Search Listings

--- a/tests/test_verify_routes.py
+++ b/tests/test_verify_routes.py
@@ -215,7 +215,7 @@ def test_admin_approve_updates_user_status(app, client):
         document_id = document.id
 
     response = client.post(
-        f"/verify/{document_id}/approve",
+        f"/admin/verify/{document_id}/approve",
         headers=_auth_headers(app, admin_id),
     )
     assert response.status_code == 200
@@ -255,7 +255,7 @@ def test_admin_reject_updates_note_and_status(app, client):
         document_id = document.id
 
     response = client.post(
-        f"/verify/{document_id}/reject",
+        f"/admin/verify/{document_id}/reject",
         json={"review_note": "Missing signature"},
         headers=_auth_headers(app, admin_id),
     )
@@ -273,6 +273,40 @@ def test_admin_reject_updates_note_and_status(app, client):
     assert refreshed_user.verification_status == "rejected"
     assert refreshed_user.is_verified is False
 
+
+
+def test_legacy_admin_routes_include_deprecation_warning(app, client):
+    """Legacy /verify admin aliases remain available but emit warning header."""
+
+    with app.app_context():
+        admin = _create_user("legacy-admin@example.com", role="admin")
+        worker = _create_user("legacy-worker@example.com")
+        document = VisaDocument(
+            user_id=worker.id,
+            filename="legacy.pdf",
+            file_path="legacy.pdf",
+            file_type="application/pdf",
+            status="pending",
+            waiver_acknowledged=True,
+        )
+        db.session.add(document)
+        db.session.commit()
+        admin_id = admin.id
+        document_id = document.id
+
+    response_pending = client.get(
+        "/verify/pending",
+        headers=_auth_headers(app, admin_id),
+    )
+    response_approve = client.post(
+        f"/verify/{document_id}/approve",
+        headers=_auth_headers(app, admin_id),
+    )
+
+    assert response_pending.status_code == 200
+    assert "deprecated" in response_pending.headers.get("Warning", "").lower()
+    assert response_approve.status_code == 200
+    assert "deprecated" in response_approve.headers.get("Warning", "").lower()
 
 def test_non_admin_cannot_access_admin_routes(app, client):
     """Workers cannot access admin-only verification routes."""
@@ -301,11 +335,11 @@ def test_non_admin_cannot_access_admin_routes(app, client):
         headers=_auth_headers(app, worker_id),
     )
     response_approve = client.post(
-        f"/verify/{document_id}/approve",
+        f"/admin/verify/{document_id}/approve",
         headers=_auth_headers(app, worker_id),
     )
     response_reject = client.post(
-        f"/verify/{document_id}/reject",
+        f"/admin/verify/{document_id}/reject",
         headers=_auth_headers(app, worker_id),
     )
 


### PR DESCRIPTION
### Motivation
- Consolidate admin verification endpoints under a clear `/admin/verify/*` namespace and provide a migration path for existing clients via temporary legacy aliases.
- Ensure upload validation tolerates common configuration formats (e.g. MIME-style values) so allowed-upload checks behave correctly across deployments.

### Description
- Added canonical admin routes and legacy aliases in `routes/verify.py`, exposing `GET /admin/verify/pending`, `POST /admin/verify/<id>/approve`, and `POST /admin/verify/<id>/reject`, while keeping `/verify/pending`, `/verify/<id>/approve`, and `/verify/<id>/reject` as temporary aliases that set a deprecation `Warning` header for legacy requests.
- Improved `_allowed_extensions()` normalization to accept values like `application/pdf` by extracting the subtype before matching extensions.
- Updated response generation in approve/reject/pending flows to attach the deprecation `Warning` header when legacy paths are used.
- Updated tests and docs to reflect the new canonical API: modified `tests/test_verify_routes.py` to exercise canonical admin paths and added a test `test_legacy_admin_routes_include_deprecation_warning` covering legacy alias behavior; updated `tests/curl_examples.md` to use `document` and `waiver` form fields and the `approve`/`reject` admin paths; added an OpenAPI-style verification endpoints table to `README.md` documenting exact methods, paths, payloads, and deprecated aliases.
- Files changed: `routes/verify.py`, `tests/test_verify_routes.py`, `tests/curl_examples.md`, and `README.md`.

### Testing
- Ran the verification route unit tests with `pytest -q tests/test_verify_routes.py`, which passed (`8 passed`).
- No database migrations were required or generated for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c5f03fc48333a68f020957f76b42)