### PR TITLE
Fix duplicate User is_active definition and add table-column regression test

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -30,11 +30,6 @@ class User(db.Model):
         db.Boolean,
         nullable=False,
         default=True,
-    )
-    is_active = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=True,
         server_default=db.text("true"),
     )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -37,3 +37,21 @@ def test_user_verification_helpers(app):
         db.session.refresh(user)
 
         assert user.verification_status == "unverified"
+
+
+def test_user_table_columns_are_unique_and_expected():
+    """Ensure the users table metadata defines each expected column exactly once."""
+
+    column_names = [column.name for column in User.__table__.columns]
+
+    assert len(column_names) == len(set(column_names))
+    assert column_names == [
+        "id",
+        "email",
+        "password_hash",
+        "role",
+        "is_verified",
+        "verification_status",
+        "is_active",
+        "created_at",
+    ]


### PR DESCRIPTION
### Motivation
- Remove a duplicated `is_active` column declaration in the `User` model to ensure runtime SQLAlchemy metadata matches intended schema and to avoid accidental autogenerate drift. 
- Ensure migrations are only produced when actual schema drift exists in the runtime database.  
- Prevent regressions by adding a test that verifies the `users` table columns are unique and match the expected set.

### Description
- Removed the duplicate `is_active` field in `models/user.py` and kept a single column definition with `default=True` and `server_default=db.text("true")` so runtime metadata has one definitive column.  
- Added a regression test `test_user_table_columns_are_unique_and_expected` in `tests/test_user_model.py` which asserts `User.__table__.columns` contains unique names and exactly the expected ordered fields.  
- Did not add any new Alembic migration files because the change is a model-definition cleanup that does not alter the runtime DB schema shape.

### Testing
- Ran `pytest -q tests/test_user_model.py` and the user model tests (including the new regression) passed.  
- Ran `pytest -q tests/test_listings_billing.py` to verify listing/billing flows that depend on user activation and those tests passed.  
- Ran `pytest -q tests/test_verify_flow.py::test_upload_requires_jwt` (selected verification test) and it passed, while a broader earlier upgrade against an on-disk SQLite DB failed due to Postgres-specific `DROP TYPE` statements in the existing migration chain.  
- Attempted `python -m flask --app app.py db upgrade heads` against SQLite to detect schema drift but it failed because the migration chain contains PostgreSQL `DROP TYPE` SQL incompatible with SQLite; an in-memory DB inspection (`db.create_all()` + `inspect`) confirmed the `users` table has a single `is_active` column so no migration was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c6c8ef74833395232fdf6db6e8d5)