### PR TITLE
Remove duplicate is_active declaration in User model

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -31,12 +31,6 @@ class User(db.Model):
         nullable=False,
         default=True,
     )
-    is_active = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=True,
-        server_default=db.text("true"),
-    )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     subscription = db.relationship(
         "EmployerSubscription",


### PR DESCRIPTION
### Motivation
- Clean up a duplicate `is_active` column declaration in the `User` model and ensure the model matches intended DB behavior (`nullable=False`, application default `True`).

### Description
- Removed the duplicate `is_active` declaration in `models/user.py`, leaving a single `is_active = db.Column(db.Boolean, nullable=False, default=True)` field and removing the redundant `server_default`-backed declaration; no new migration was generated because existing migration history already handles the DB-level default/backfill for `users.is_active`.

### Testing
- Ran `pytest -q tests/test_user_model.py`, which passed (1 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cb2d666883339abe2e9c97696762)