### PR TITLE
Validate verification uploads by MIME type

### DIFF
--- a/routes/verify.py
+++ b/routes/verify.py
@@ -22,7 +22,7 @@ from utils.request_validation import parse_json_request
 verify_bp = Blueprint("verify", __name__)
 
 MAX_UPLOAD_SIZE_DEFAULT = 10 * 1024 * 1024  # 10 MB
-ALLOWED_EXTENSIONS_DEFAULT = {"jpeg", "jpg", "png", "pdf"}
+ALLOWED_UPLOAD_TYPES_DEFAULT = {"image/jpeg", "image/png", "application/pdf"}
 
 
 def _get_current_user() -> User | None:
@@ -67,25 +67,21 @@ def _parse_bool(value: object) -> bool | None:
     return None
 
 
-def _allowed_extensions() -> set[str]:
+def _allowed_upload_types() -> set[str]:
     configured = current_app.config.get("ALLOWED_UPLOAD_TYPES")
     if not configured:
-        return set(ALLOWED_EXTENSIONS_DEFAULT)
+        return set(ALLOWED_UPLOAD_TYPES_DEFAULT)
     if isinstance(configured, str):
         values: Iterable[str] = configured.split(",")
     else:
         values = configured
     normalized = {
-        item.strip().lower().lstrip(".")
+        item.strip().lower()
         for item in values
         if isinstance(item, str) and item.strip()
     }
     if not normalized:
-        return set(ALLOWED_EXTENSIONS_DEFAULT)
-    if "jpeg" in normalized:
-        normalized.add("jpg")
-    if "jpg" in normalized:
-        normalized.add("jpeg")
+        return set(ALLOWED_UPLOAD_TYPES_DEFAULT)
     return normalized
 
 
@@ -93,9 +89,10 @@ def _validate_document(file: FileStorage) -> None:
     if file.filename is None or file.filename.strip() == "":
         raise BadRequest("A document file is required.")
 
-    extension = file.filename.rsplit(".", 1)[-1].lower()
-    if extension not in _allowed_extensions():
-        allowed = ", ".join(sorted(_allowed_extensions()))
+    mimetype = (file.mimetype or "").strip().lower()
+    allowed_upload_types = _allowed_upload_types()
+    if mimetype not in allowed_upload_types:
+        allowed = ", ".join(sorted(allowed_upload_types))
         raise BadRequest(f"File type not allowed. Allowed types: {allowed}.")
 
     max_size = int(current_app.config.get("MAX_UPLOAD_SIZE", MAX_UPLOAD_SIZE_DEFAULT))

--- a/tests/test_verify_flow.py
+++ b/tests/test_verify_flow.py
@@ -87,6 +87,51 @@ def test_upload_and_status(app: Flask, client):
     assert refreshed_user.verification_status == "pending"
 
 
+
+def test_upload_accepts_allowed_mimetype_with_unexpected_extension(app: Flask, client):
+    """Upload succeeds when MIME type is allowed even if extension is unexpected."""
+
+    _, token = _register_and_login(
+        app, client, "mime-flow-allowed@example.com", "secret123"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(b"PDF data"), "document.unknown", "application/pdf"),
+            "waiver": "true",
+        },
+        headers=headers,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 201
+
+
+def test_upload_rejects_disallowed_mimetype_with_pdf_extension(app: Flask, client):
+    """Upload fails when MIME type is disallowed even if filename uses an allowed extension."""
+
+    _, token = _register_and_login(
+        app, client, "mime-flow-rejected@example.com", "secret123"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(b"not really a pdf"), "document.pdf", "text/plain"),
+            "waiver": "true",
+        },
+        headers=headers,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Bad Request"
+
+
 def test_admin_approve(app: Flask, client):
     """Admins can approve documents via the review endpoint."""
 

--- a/tests/test_verify_routes.py
+++ b/tests/test_verify_routes.py
@@ -60,6 +60,51 @@ def test_upload_document_creates_pending_record(app, client):
     assert stored_file.exists()
 
 
+
+def test_upload_document_accepts_allowed_mimetype_with_nonstandard_extension(app, client):
+    """Upload succeeds when MIME type is allowed, regardless of filename extension."""
+
+    with app.app_context():
+        user = _create_user("mime-allowed@example.com")
+        user_id = user.id
+
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(b"PDF data"), "passport.bin", "application/pdf"),
+            "waiver": "true",
+        },
+        headers=_auth_headers(app, user_id),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["status"] == "pending"
+
+
+def test_upload_document_rejects_disallowed_mimetype_even_with_allowed_extension(app, client):
+    """Upload fails when MIME type is not allowed, even with an allowed extension."""
+
+    with app.app_context():
+        user = _create_user("mime-rejected@example.com")
+        user_id = user.id
+
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(b"PDF data"), "passport.pdf", "text/plain"),
+            "waiver": "true",
+        },
+        headers=_auth_headers(app, user_id),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Bad Request"
+
+
 def test_status_endpoint_returns_latest_document(app, client):
     """Status endpoint includes user status and latest document metadata."""
 


### PR DESCRIPTION
### Motivation
- Move upload validation from filename extensions to MIME types so uploaded content is validated based on `file.mimetype` and the `ALLOWED_UPLOAD_TYPES` configuration. 
- Ensure the verification flow enforces a consistent, configurable allowlist of MIME types and cover the behavior in tests. 

### Description
- Replace extension-based logic with a MIME-based allowlist: introduce `ALLOWED_UPLOAD_TYPES_DEFAULT` and `_allowed_upload_types()` and update `_validate_document()` to validate `file.mimetype` against `ALLOWED_UPLOAD_TYPES`. 
- Update tests and add new cases in `tests/test_verify_routes.py` and `tests/test_verify_flow.py` to assert that an allowed MIME is accepted even with a nonstandard filename extension and that a disallowed MIME is rejected even if the filename extension looks allowed. 
- No database model changes or migrations were required.

### Testing
- Ran `pytest -q tests/test_verify_routes.py tests/test_verify_flow.py` and the updated tests passed (`15 passed`, with warnings). 
- All changes are covered by the new/updated automated tests referenced above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cb2f99b88333baa56d017d98adc0)