### PR TITLE
Enforce secure secret configuration outside testing/development contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # J1hub
-The j1 app that will be popular in the dells 
+
+Flask backend for J1hub.
+
+## Required environment variables
+
+For non-testing deployments (`TESTING=false`), the app now enforces secure secret configuration at startup.
+
+Set the following variables before running in production-like environments:
+
+- `SECRET_KEY` (required): Flask session/app secret. Must not be default placeholders like `change-me`.
+- `JWT_SECRET_KEY` (required): JWT signing key. Must not be default placeholders like `change-me`.
+
+## Optional environment variables
+
+- `TESTING` (default: `false`): When `true`, secret placeholder checks are relaxed for test runs.
+- `DEBUG` (default: `false`): Development-safe mode; strict secret enforcement is relaxed.
+- `FLASK_ENV` / `ENV` (default: `production`): If set to `development`, strict secret enforcement is relaxed.
+- `DATABASE_URL` (default: `sqlite:///app.db`)
+- `UPLOAD_DIR` (default: `workspace/uploads`)
+- `MAX_UPLOAD_SIZE` (default: `10485760`)
+- `ALLOWED_UPLOAD_TYPES` (default: `image/jpeg,image/png,application/pdf`)
+- `ORIGINS` (default: `*`)
+- `RATE_LIMIT` (default: `60 per minute`)
+- `RATELIMIT_STORAGE_URI` (default: `memory://`)
+- `RATELIMIT_KEY_PREFIX` (optional)
+- Stripe/billing keys:
+  - `STRIPE_SECRET_KEY`
+  - `STRIPE_WEBHOOK_SECRET`
+  - `PRICE_LISTING`
+  - `PRICE_MONTHLY`
+  - `BILLING_SUCCESS_URL`
+  - `BILLING_CANCEL_URL`
+
+## Quick start
+
+```bash
+export SECRET_KEY='replace-with-long-random-secret'
+export JWT_SECRET_KEY='replace-with-different-long-random-secret'
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -157,6 +157,9 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     app = Flask(__name__)
     app.config.from_object(config_class)
 
+    if hasattr(config_class, "validate_security_settings"):
+        config_class.validate_security_settings()
+
     # Core subsystems
     db.init_app(app)
     migrate.init_app(app, db)

--- a/config.py
+++ b/config.py
@@ -15,6 +15,9 @@ class Config:
     # Core
     SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
     JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", SECRET_KEY)
+    TESTING = os.getenv("TESTING", "false").lower() == "true"
+    DEBUG = os.getenv("DEBUG", "false").lower() == "true"
+    ENV = os.getenv("FLASK_ENV") or os.getenv("ENV") or "production"
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///app.db")
     SQLALCHEMY_DATABASE_URI = DATABASE_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -44,3 +47,35 @@ class Config:
     PRICE_MONTHLY = os.getenv("PRICE_MONTHLY")
     BILLING_SUCCESS_URL = os.getenv("BILLING_SUCCESS_URL")
     BILLING_CANCEL_URL = os.getenv("BILLING_CANCEL_URL")
+
+    _INSECURE_SECRET_VALUES = {"", "change-me", "changeme", "default", "placeholder"}
+
+    @classmethod
+    def should_enforce_secret_validation(cls) -> bool:
+        """Return whether strict secret validation should be enforced."""
+        return not bool(getattr(cls, "TESTING", False)) and not (
+            bool(getattr(cls, "DEBUG", False))
+            or str(getattr(cls, "ENV", "")).lower() == "development"
+        )
+
+    @classmethod
+    def validate_security_settings(cls) -> None:
+        """Validate runtime security settings for non-safe environments."""
+        if not cls.should_enforce_secret_validation():
+            return
+
+        secret_key = str(getattr(cls, "SECRET_KEY", "") or "").strip()
+        jwt_secret_key = str(getattr(cls, "JWT_SECRET_KEY", "") or "").strip()
+
+        missing_or_insecure = []
+        if secret_key.lower() in cls._INSECURE_SECRET_VALUES:
+            missing_or_insecure.append("SECRET_KEY")
+        if jwt_secret_key.lower() in cls._INSECURE_SECRET_VALUES:
+            missing_or_insecure.append("JWT_SECRET_KEY")
+
+        if missing_or_insecure:
+            keys = ", ".join(missing_or_insecure)
+            raise RuntimeError(
+                f"Refusing to start with insecure default secrets ({keys}). "
+                "Set strong SECRET_KEY and JWT_SECRET_KEY values in the environment."
+            )

--- a/tests/test_security_features.py
+++ b/tests/test_security_features.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
 from flask import Flask
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -75,3 +76,38 @@ def test_json_error_shape_for_invalid_request(tmp_path):
     assert payload["error"] == "Bad Request"
     assert "Request content type" in payload["detail"]
     assert payload["request_id"]
+
+
+def test_startup_rejects_default_secrets_in_non_testing_context(tmp_path):
+    upload_dir = tmp_path / "uploads"
+
+    class ProductionConfig(Config):
+        TESTING = False
+        DEBUG = False
+        ENV = "production"
+        SECRET_KEY = "change-me"
+        JWT_SECRET_KEY = "change-me"
+        SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        SQLALCHEMY_TRACK_MODIFICATIONS = False
+        UPLOAD_DIR = str(upload_dir)
+
+    with pytest.raises(RuntimeError, match="Refusing to start"):
+        create_app(ProductionConfig)
+
+
+def test_startup_allows_default_secrets_when_testing_enabled(tmp_path):
+    upload_dir = tmp_path / "uploads"
+
+    class TestingConfig(Config):
+        TESTING = True
+        DEBUG = False
+        ENV = "production"
+        SECRET_KEY = "change-me"
+        JWT_SECRET_KEY = "change-me"
+        SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        SQLALCHEMY_TRACK_MODIFICATIONS = False
+        UPLOAD_DIR = str(upload_dir)
+
+    app = create_app(TestingConfig)
+
+    assert app.testing is True


### PR DESCRIPTION
### Motivation
- Prevent accidental startup in production-like environments when `SECRET_KEY` or `JWT_SECRET_KEY` are unset or left as insecure placeholders.
- Make secret validation environment-aware so tests and development workflows remain convenient while production is hardened.

### Description
- Add `TESTING`, `DEBUG`, and `ENV` flags to `Config` and introduce `_INSECURE_SECRET_VALUES`, `should_enforce_secret_validation()`, and `validate_security_settings()` to detect placeholder/empty secrets in unsafe contexts (`config.py`).
- Invoke `config_class.validate_security_settings()` from the app factory immediately after loading config so invalid secrets cause an early startup failure (`app.py`).
- Add tests that assert startup is rejected with default placeholder secrets in a non-testing production config and that startup is allowed when `TESTING=True` (`tests/test_security_features.py`).
- Document required environment variables and behavior for production vs testing/development in `README.md` and do not change database/schema (no migrations).

### Testing
- Ran `pytest -q tests/test_security_features.py` and all tests passed (`5 passed`).
- No DB migrations were generated because no model/schema changes were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cb3b4480833393c043cb4442f61d)