### PR TITLE
Prevent duplicate listing applications with DB constraint and API guard

### DIFF
--- a/migrations/versions/a4f9d2c6e1b7_add_unique_constraint_to_applications.py
+++ b/migrations/versions/a4f9d2c6e1b7_add_unique_constraint_to_applications.py
@@ -1,0 +1,34 @@
+"""Add unique constraint for applications by user and listing.
+
+Revision ID: a4f9d2c6e1b7
+Revises: 1b5a52d73d61
+Create Date: 2026-02-14 00:00:00.000000
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a4f9d2c6e1b7"
+down_revision = "1b5a52d73d61"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT_NAME = "uq_applications_user_listing"
+
+
+def upgrade() -> None:
+    """Apply schema changes."""
+
+    op.create_unique_constraint(
+        CONSTRAINT_NAME,
+        "applications",
+        ["user_id", "listing_id"],
+    )
+
+
+def downgrade() -> None:
+    """Revert schema changes."""
+
+    op.drop_constraint(CONSTRAINT_NAME, "applications", type_="unique")

--- a/models/application.py
+++ b/models/application.py
@@ -9,6 +9,9 @@ class Application(db.Model):
     """Represents a worker application for a listing."""
 
     __tablename__ = "applications"
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "listing_id", name="uq_applications_user_listing"),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)

--- a/routes/listings.py
+++ b/routes/listings.py
@@ -12,7 +12,8 @@ from flask_jwt_extended import (
     verify_jwt_in_request,
 )
 from sqlalchemy import and_, or_
-from werkzeug.exceptions import BadRequest, Forbidden
+from sqlalchemy.exc import IntegrityError
+from werkzeug.exceptions import BadRequest, Conflict, Forbidden
 
 from models import db
 from models.application import Application
@@ -316,8 +317,19 @@ def apply_to_listing(listing_id: int):
     if not message:
         raise BadRequest("message is required")
 
+    existing_application = Application.query.filter_by(
+        user_id=user.id,
+        listing_id=listing.id,
+    ).first()
+    if existing_application:
+        raise Conflict("You have already applied to this listing.")
+
     application = Application(user_id=user.id, listing_id=listing.id, message=message)
     db.session.add(application)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        raise Conflict("You have already applied to this listing.")
 
     return jsonify(application.to_dict()), 201

--- a/tests/test_listing_applications.py
+++ b/tests/test_listing_applications.py
@@ -1,0 +1,101 @@
+"""Tests for listing application flow."""
+
+from __future__ import annotations
+
+from flask_jwt_extended import create_access_token
+
+from models import db
+from models.application import Application
+from models.listing import Listing
+from models.user import User
+
+
+APPLY_PAYLOAD = {"message": "I am interested in this opportunity."}
+
+
+def _auth_header(app, user_id: int) -> dict[str, str]:
+    with app.app_context():
+        token = create_access_token(identity=str(user_id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_listing_with_worker() -> tuple[int, int]:
+    employer = User(email="employer@app.test", password_hash="hash", role="employer")
+    worker = User(
+        email="worker@app.test",
+        password_hash="hash",
+        role="worker",
+        is_verified=True,
+        verification_status="approved",
+    )
+    db.session.add_all([employer, worker])
+    db.session.flush()
+
+    listing = Listing(
+        category="job",
+        title="Seasonal Role",
+        description="Role details",
+        contact_method="email",
+        contact_value="employer@app.test",
+        created_by=employer.id,
+        is_public=True,
+        is_active=True,
+    )
+    db.session.add(listing)
+    db.session.commit()
+
+    return listing.id, worker.id
+
+
+def test_apply_to_listing_success(app, client):
+    """Workers can apply once to an active listing."""
+
+    with app.app_context():
+        listing_id, worker_id = _create_listing_with_worker()
+
+    response = client.post(
+        f"/listings/{listing_id}/apply",
+        json=APPLY_PAYLOAD,
+        headers=_auth_header(app, worker_id),
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["listing_id"] == listing_id
+    assert payload["user_id"] == worker_id
+
+    with app.app_context():
+        assert Application.query.filter_by(
+            user_id=worker_id,
+            listing_id=listing_id,
+        ).count() == 1
+
+
+def test_apply_to_listing_rejects_duplicate(app, client):
+    """Duplicate applications return a conflict response."""
+
+    with app.app_context():
+        listing_id, worker_id = _create_listing_with_worker()
+
+    first_response = client.post(
+        f"/listings/{listing_id}/apply",
+        json=APPLY_PAYLOAD,
+        headers=_auth_header(app, worker_id),
+    )
+    assert first_response.status_code == 201
+
+    duplicate_response = client.post(
+        f"/listings/{listing_id}/apply",
+        json=APPLY_PAYLOAD,
+        headers=_auth_header(app, worker_id),
+    )
+
+    assert duplicate_response.status_code == 409
+    duplicate_payload = duplicate_response.get_json()
+    assert duplicate_payload["detail"] == "You have already applied to this listing."
+
+    with app.app_context():
+        assert Application.query.filter_by(
+            user_id=worker_id,
+            listing_id=listing_id,
+        ).count() == 1


### PR DESCRIPTION
### Motivation
- Prevent workers from creating duplicate applications for the same listing at the application layer and database layer to avoid inconsistent data and race conditions.

### Description
- Add a database-level unique constraint on `(user_id, listing_id)` by setting `__table_args__` in `models/application.py` to `uq_applications_user_listing`.
- Add an Alembic migration `migrations/versions/a4f9d2c6e1b7_add_unique_constraint_to_applications.py` to create and drop the unique constraint in `upgrade()`/`downgrade()`.
- Update `routes/listings.py::apply_to_listing` to proactively check for an existing application and return a `409 Conflict` with a clear message, and add an `IntegrityError` fallback to handle concurrent inserts safely.
- Add tests in `tests/test_listing_applications.py` to assert first apply succeeds (`201`) and duplicate apply is rejected (`409`) while keeping the DB row count at one.

### Testing
- Ran `pytest -q tests/test_listing_applications.py tests/test_listings_billing.py` and the test suite completed with `5 passed` (new application tests and existing billing tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cb45d31883338e48f0cd92621994)