### PR TITLE
Remove duplicate User.is_active model field

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -31,12 +31,6 @@ class User(db.Model):
         nullable=False,
         default=True,
     )
-    is_active = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=True,
-        server_default=db.text("true"),
-    )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     subscription = db.relationship(
         "EmployerSubscription",


### PR DESCRIPTION
### Motivation
- Remove a duplicate `is_active` column declaration in the `User` model to eliminate ambiguity and keep the SQLAlchemy model consistent with the migration history and intended database defaults.

### Description
- Deleted the redundant `is_active` declaration in `models/user.py` and preserved a single `is_active = db.Column(db.Boolean, nullable=False, default=True)` definition so the model reflects `nullable=False` with a Python-side default of `True`.

### Testing
- Ran `python -m compileall models/user.py` to validate the module compiles successfully, and executed repository scans (`rg`) to confirm migrations in `migrations/versions/` set and remove any temporary `server_default` values during upgrades; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e9db3f0c8333855c5203fb51a406)