### PR TITLE
Resolve Alembic split heads and harden user verification migrations

### DIFF
--- a/migrations/versions/1b5a52d73d61_update_user_verification_fields.py
+++ b/migrations/versions/1b5a52d73d61_update_user_verification_fields.py
@@ -2,6 +2,7 @@
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 # revision identifiers, used by Alembic.
@@ -23,59 +24,69 @@ VERIFICATION_STATUS_VALUES = (
 def upgrade() -> None:
     """Apply the verification status and activation updates."""
 
-    op.add_column(
-        "users",
-        sa.Column(
-            "verification_status_tmp",
-            sa.String(length=32),
-            nullable=False,
-            server_default=sa.text("'unverified'"),
-        ),
-    )
-    op.execute("UPDATE users SET verification_status_tmp = verification_status")
-    op.alter_column(
-        "users",
-        "verification_status_tmp",
-        server_default=None,
-        existing_type=sa.String(length=32),
-    )
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    user_columns = {column["name"]: column for column in inspector.get_columns("users")}
 
-    op.drop_column("users", "verification_status")
-    op.alter_column(
-        "users",
-        "verification_status_tmp",
-        new_column_name="verification_status",
-        existing_type=sa.String(length=32),
-    )
-    op.alter_column(
-        "users",
-        "verification_status",
-        server_default=None,
-        existing_type=sa.String(length=32),
-    )
+    verification_status_column = user_columns.get("verification_status")
+    verification_status_type = verification_status_column["type"] if verification_status_column else None
+    verification_status_is_enum = hasattr(verification_status_type, "enums")
+
+    if verification_status_column and verification_status_is_enum:
+        op.add_column(
+            "users",
+            sa.Column(
+                "verification_status_tmp",
+                sa.String(length=32),
+                nullable=False,
+                server_default=sa.text("'unverified'"),
+            ),
+        )
+        op.execute("UPDATE users SET verification_status_tmp = verification_status")
+        op.alter_column(
+            "users",
+            "verification_status_tmp",
+            server_default=None,
+            existing_type=sa.String(length=32),
+        )
+
+        op.drop_column("users", "verification_status")
+        op.alter_column(
+            "users",
+            "verification_status_tmp",
+            new_column_name="verification_status",
+            existing_type=sa.String(length=32),
+        )
+        op.alter_column(
+            "users",
+            "verification_status",
+            server_default=None,
+            existing_type=sa.String(length=32),
+        )
 
     verification_status_enum = sa.Enum(name=VERIFICATION_STATUS_ENUM)
-    verification_status_enum.drop(op.get_bind(), checkfirst=True)
+    verification_status_enum.drop(bind, checkfirst=True)
 
-    op.add_column(
-        "users",
-        sa.Column(
+    if "is_active" not in user_columns:
+        op.add_column(
+            "users",
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+        )
+
+        users = sa.table("users", sa.column("is_active", sa.Boolean()))
+        op.execute(users.update().where(users.c.is_active.is_(None)).values(is_active=True))
+
+        op.alter_column(
+            "users",
             "is_active",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.true(),
-        ),
-    )
-
-    users = sa.table("users", sa.column("is_active", sa.Boolean()))
-    op.execute(users.update().where(users.c.is_active.is_(None)).values(is_active=True))
-
-    op.alter_column(
-        "users",
-        "is_active",
-        server_default=None,
-        existing_type=sa.Boolean(),
-    )
+            server_default=None,
+            existing_type=sa.Boolean(),
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/b77b0a6c2c1a_add_visa_documents_and_user_flags.py
+++ b/migrations/versions/b77b0a6c2c1a_add_visa_documents_and_user_flags.py
@@ -75,7 +75,7 @@ def upgrade() -> None:
         unique=False,
     )
 
-    user_columns = {column["name"] for column in inspector.get_columns("users")}
+    user_columns = {column["name"]: column for column in inspector.get_columns("users")}
 
     verification_status_enum = sa.Enum(
         "unverified",
@@ -86,15 +86,17 @@ def upgrade() -> None:
     )
 
     if "verification_status" in user_columns:
-        op.alter_column(
-            "users",
-            "verification_status",
-            existing_type=verification_status_enum,
-            type_=sa.String(length=32),
-            existing_nullable=False,
-            postgresql_using="verification_status::text",
-        )
-        op.execute(f"DROP TYPE IF EXISTS {USER_VERIFICATION_STATUS_ENUM}")
+        verification_status_type = user_columns["verification_status"]["type"]
+        if hasattr(verification_status_type, "enums"):
+            op.alter_column(
+                "users",
+                "verification_status",
+                existing_type=verification_status_type,
+                type_=sa.String(length=32),
+                existing_nullable=False,
+                postgresql_using="verification_status::text",
+            )
+            op.execute(f"DROP TYPE IF EXISTS {USER_VERIFICATION_STATUS_ENUM}")
     else:
         op.add_column(
             "users",
@@ -128,28 +130,30 @@ def downgrade() -> None:
     table_names = set(inspector.get_table_names())
 
     if "users" in table_names:
-        user_columns = {column["name"] for column in inspector.get_columns("users")}
+        user_columns = {column["name"]: column for column in inspector.get_columns("users")}
 
         if "is_active" in user_columns:
             op.drop_column("users", "is_active")
 
         if "verification_status" in user_columns:
-            verification_status_enum = sa.Enum(
-                "unverified",
-                "pending",
-                "approved",
-                "rejected",
-                name=USER_VERIFICATION_STATUS_ENUM,
-            )
-            verification_status_enum.create(bind, checkfirst=True)
-            op.alter_column(
-                "users",
-                "verification_status",
-                existing_type=sa.String(length=32),
-                type_=verification_status_enum,
-                existing_nullable=False,
-                postgresql_using="verification_status::verification_status",
-            )
+            verification_status_type = user_columns["verification_status"]["type"]
+            if not hasattr(verification_status_type, "enums"):
+                verification_status_enum = sa.Enum(
+                    "unverified",
+                    "pending",
+                    "approved",
+                    "rejected",
+                    name=USER_VERIFICATION_STATUS_ENUM,
+                )
+                verification_status_enum.create(bind, checkfirst=True)
+                op.alter_column(
+                    "users",
+                    "verification_status",
+                    existing_type=sa.String(length=32),
+                    type_=verification_status_enum,
+                    existing_nullable=False,
+                    postgresql_using="verification_status::verification_status",
+                )
 
     if "visa_documents" in table_names:
         existing_indexes = {index["name"] for index in inspector.get_indexes("visa_documents")}

--- a/migrations/versions/c3e9f4a1d2b7_merge_user_verification_heads.py
+++ b/migrations/versions/c3e9f4a1d2b7_merge_user_verification_heads.py
@@ -1,0 +1,21 @@
+"""Merge user verification migration branches.
+
+Revision ID: c3e9f4a1d2b7
+Revises: 1b5a52d73d61, b77b0a6c2c1a
+Create Date: 2026-02-21
+"""
+
+# revision identifiers, used by Alembic.
+revision = "c3e9f4a1d2b7"
+down_revision = ("1b5a52d73d61", "b77b0a6c2c1a")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge branches without additional schema operations."""
+
+
+
+def downgrade() -> None:
+    """Split merged branches without additional schema operations."""


### PR DESCRIPTION
### Motivation
- The migration graph diverged after `8a2f5e85a0e4`, producing two parallel heads (`1b5a52d73d61` and `b77b0a6c2c1a`) which can cause conflicting operations during `upgrade head` in production.
- Ensure safe, idempotent type and column transitions for `users.verification_status` and `users.is_active` so applying either branch (or both) does not produce type-mismatch errors or repeated operations.
- Provide a single canonical head so CI / production upgrades have a deterministic path.

### Description
- Added a merge migration `migrations/versions/c3e9f4a1d2b7_merge_user_verification_heads.py` with `down_revision = ("1b5a52d73d61", "b77b0a6c2c1a")` to collapse the two heads into one canonical head.
- Updated `migrations/versions/1b5a52d73d61_update_user_verification_fields.py` to inspect the live schema (using `inspect`) and only convert `verification_status` when it is an ENUM, and to add `is_active` only when it does not already exist.
- Updated `migrations/versions/b77b0a6c2c1a_add_visa_documents_and_user_flags.py` to inspect `users.verification_status` type and only cast enum->string when the column is actually an enum, and to make the downgrade cast back to enum only when the column is currently a string; also changed local column inspection collections to preserve type metadata.
- Committed the changes into the current branch (commit recorded in the repo) so the migration graph now lists a single head file (`c3e9f4a1d2b7`).

### Testing
- Ran a migration-head discovery script (Python) against `migrations/versions` to compute heads from revision metadata and confirmed the only head is `c3e9f4a1d2b7` (success).
- Compiled all migration scripts with `python -m compileall migrations/versions` to validate syntax (success).
- Attempted `alembic heads` in this environment, but it failed due to missing Alembic `script_location` in local config (expected environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea28362883338bf95470342a832a)