### PR TITLE
Require env-backed SECRET_KEY/JWT_SECRET_KEY outside testing

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,11 +151,27 @@ migrate = Migrate()
 jwt = JWTManager()
 limiter = Limiter(key_func=get_remote_address)
 
+def _validate_secure_keys(app: Flask) -> None:
+    """Ensure required signing keys are configured for non-testing runtime."""
+
+    if app.config.get("TESTING"):
+        return
+
+    required_keys = ("SECRET_KEY", "JWT_SECRET_KEY")
+    missing = [key for key in required_keys if not app.config.get(key)]
+    if missing:
+        missing_keys = ", ".join(missing)
+        raise RuntimeError(
+            "Missing required security configuration: "
+            f"{missing_keys}. Set them via environment variables before startup."
+        )
+
 
 def create_app(config_class: type[Config] = Config) -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
     app.config.from_object(config_class)
+    _validate_secure_keys(app)
 
     # Core subsystems
     db.init_app(app)

--- a/config.py
+++ b/config.py
@@ -13,8 +13,8 @@ class Config:
     """
 
     # Core
-    SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
-    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", SECRET_KEY)
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///app.db")
     SQLALCHEMY_DATABASE_URI = DATABASE_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -44,3 +44,19 @@ class Config:
     PRICE_MONTHLY = os.getenv("PRICE_MONTHLY")
     BILLING_SUCCESS_URL = os.getenv("BILLING_SUCCESS_URL")
     BILLING_CANCEL_URL = os.getenv("BILLING_CANCEL_URL")
+
+
+class DevelopmentConfig(Config):
+    """Local developer configuration with temporary keys for convenience."""
+
+    DEBUG = True
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key")
+    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-jwt-secret-key")
+
+
+class TestingConfig(Config):
+    """Testing configuration with lightweight temporary keys."""
+
+    TESTING = True
+    SECRET_KEY = "test-secret-key"
+    JWT_SECRET_KEY = "test-jwt-secret-key"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
@@ -24,3 +26,37 @@ def test_blueprints_registered(app):
     required = {"auth", "verify", "listings"}
     assert required.issubset(bps)
     # billing is optional; do not require it for tests
+
+
+def test_startup_validation_raises_when_keys_missing(tmp_path):
+    """Non-testing app startup should fail when required secure keys are absent."""
+
+    from app import create_app
+    from config import Config
+
+    class MissingKeyConfig(Config):
+        SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        SQLALCHEMY_TRACK_MODIFICATIONS = False
+        UPLOAD_DIR = str(tmp_path / "uploads")
+        SECRET_KEY = None
+        JWT_SECRET_KEY = None
+
+    with pytest.raises(RuntimeError, match="Missing required security configuration"):
+        create_app(MissingKeyConfig)
+
+
+def test_dev_config_allows_local_temp_keys(tmp_path):
+    """Development config should allow temporary fallback keys for local dev ergonomics."""
+
+    from app import create_app
+    from config import DevelopmentConfig
+
+    class LocalDevConfig(DevelopmentConfig):
+        SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        SQLALCHEMY_TRACK_MODIFICATIONS = False
+        UPLOAD_DIR = str(tmp_path / "uploads")
+
+    app = create_app(LocalDevConfig)
+
+    assert app.config["SECRET_KEY"]
+    assert app.config["JWT_SECRET_KEY"]


### PR DESCRIPTION
### Motivation

- Prevent accidental use of weak or hardcoded signing secrets in production by ensuring `SECRET_KEY` and `JWT_SECRET_KEY` are provided via environment variables in non-testing runtime.
- Preserve developer ergonomics by allowing explicit `DevelopmentConfig`/`TestingConfig` to provide lightweight keys for local development and automated tests.

### Description

- Removed insecure default fallbacks for `SECRET_KEY` and `JWT_SECRET_KEY` from the base `Config` so production/non-test usage depends on environment variables and added `DevelopmentConfig` and `TestingConfig` with explicit temporary keys for local and test usage (`config.py`).
- Added `_validate_secure_keys(app: Flask)` and call in `create_app` to raise a clear `RuntimeError` when required keys are missing outside testing (`app.py`).
- Added tests to `tests/test_app_factory.py` to assert that startup validation fails when keys are absent and that `DevelopmentConfig` permits temporary local keys, and adjusted imports to include `pytest`.
- Files changed: `config.py`, `app.py`, and `tests/test_app_factory.py`; there are no database model or migration changes.

### Testing

- Ran `pytest -q tests/test_app_factory.py tests/test_security_features.py` which completed successfully with `7 passed`.
- Ran `pytest -q tests/test_app_factory.py` which completed successfully with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea2c5c888333aac5379e4bfd9478)