### PR TITLE
Require signed Stripe billing webhooks and enforce webhook secret config

### DIFF
--- a/routes/billing.py
+++ b/routes/billing.py
@@ -186,11 +186,11 @@ def billing_webhook():
     sig_header = request.headers.get("Stripe-Signature")
     webhook_secret = current_app.config.get("STRIPE_WEBHOOK_SECRET")
 
+    if not webhook_secret:
+        return jsonify({"error": "Stripe webhook secret is not configured."}), 500
+
     try:
-        if webhook_secret:
-            event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
-        else:  # pragma: no cover - fallback path
-            event = stripe.Event.construct_from(request.get_json(force=True), stripe.api_key)
+        event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
     except (ValueError, stripe.error.SignatureVerificationError):
         return jsonify({"error": "Invalid webhook signature."}), 400
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -18,6 +18,28 @@ def _create_employer(email: str = "employer@example.com") -> int:
     return user.id
 
 
+def test_webhook_requires_webhook_secret(app, client):
+    """Webhook should return server configuration error when secret is missing."""
+
+    app.config["STRIPE_WEBHOOK_SECRET"] = None
+
+    response = client.post(
+        "/billing/webhook", data=b"{}", headers={"Stripe-Signature": "sig"}
+    )
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Stripe webhook secret is not configured."}
+
+
+def test_webhook_rejects_unsigned_payload(app, client):
+    """Webhook should reject payloads that are not signed by Stripe."""
+
+    response = client.post("/billing/webhook", data=b"{}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid webhook signature."}
+
+
 def test_webhook_adds_listing_credits(app, client, monkeypatch):
     """Webhook should add listing credits for completed checkout sessions."""
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated webhook event parsing by removing the unsigned fallback and requiring `STRIPE_WEBHOOK_SECRET` to be set. 
- Fail fast with an explicit server configuration error when the webhook secret is missing to avoid silently accepting unauthenticated events. 
- Preserve existing signed webhook handling for listing credits and subscription updates.

### Description
- In `routes/billing.py` return `500` when `STRIPE_WEBHOOK_SECRET` is not configured and remove the unsigned `stripe.Event.construct_from` fallback so only `stripe.Webhook.construct_event` is used. 
- Consolidated verification to `stripe.Webhook.construct_event(payload, sig_header, webhook_secret)` and retained event handling that calls `_handle_listing_purchase` and `_handle_subscription_event`. 
- Added tests in `tests/test_billing.py`: `test_webhook_requires_webhook_secret` and `test_webhook_rejects_unsigned_payload`, while keeping existing signed-flow tests for listing credits and subscription updates. 
- Files changed: `routes/billing.py` and `tests/test_billing.py`.

### Testing
- Ran `pytest -q tests/test_billing.py` and all tests passed. 
- The test suite validates that missing webhook secret returns a `500` configuration error, unsigned payloads are rejected with `400`, and signed webhook handling for listing and subscription flows still works (existing tests remain passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea2e13108333aef6188f4d9d270f)