### PR TITLE
Enforce unique worker applications per listing

### DIFF
--- a/migrations/versions/2f4c6b8a9d10_add_unique_constraint_on_applications.py
+++ b/migrations/versions/2f4c6b8a9d10_add_unique_constraint_on_applications.py
@@ -1,0 +1,71 @@
+"""Add unique constraint for one application per user/listing pair."""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = "2f4c6b8a9d10"
+down_revision = ("1b5a52d73d61", "b77b0a6c2c1a")
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT_NAME = "uq_applications_user_id_listing_id"
+
+
+def upgrade() -> None:
+    """Apply the applications uniqueness guarantee safely."""
+
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    duplicate_cleanup_sql = sa.text(
+        """
+        DELETE FROM applications
+        WHERE id IN (
+            SELECT id
+            FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY user_id, listing_id
+                        ORDER BY id
+                    ) AS rn
+                FROM applications
+            ) ranked
+            WHERE ranked.rn > 1
+        )
+        """
+    )
+    op.execute(duplicate_cleanup_sql)
+
+    existing_unique_constraints = {
+        constraint["name"]
+        for constraint in inspector.get_unique_constraints("applications")
+        if constraint.get("name")
+    }
+
+    if CONSTRAINT_NAME not in existing_unique_constraints:
+        with op.batch_alter_table("applications") as batch_op:
+            batch_op.create_unique_constraint(
+                CONSTRAINT_NAME,
+                ["user_id", "listing_id"],
+            )
+
+
+def downgrade() -> None:
+    """Remove the applications unique constraint."""
+
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_unique_constraints = {
+        constraint["name"]
+        for constraint in inspector.get_unique_constraints("applications")
+        if constraint.get("name")
+    }
+
+    if CONSTRAINT_NAME in existing_unique_constraints:
+        with op.batch_alter_table("applications") as batch_op:
+            batch_op.drop_constraint(CONSTRAINT_NAME, type_="unique")

--- a/models/application.py
+++ b/models/application.py
@@ -9,6 +9,13 @@ class Application(db.Model):
     """Represents a worker application for a listing."""
 
     __tablename__ = "applications"
+    __table_args__ = (
+        db.UniqueConstraint(
+            "user_id",
+            "listing_id",
+            name="uq_applications_user_id_listing_id",
+        ),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)

--- a/routes/listings.py
+++ b/routes/listings.py
@@ -12,6 +12,7 @@ from flask_jwt_extended import (
     verify_jwt_in_request,
 )
 from sqlalchemy import and_, or_
+from sqlalchemy.exc import IntegrityError
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from models import db
@@ -316,8 +317,19 @@ def apply_to_listing(listing_id: int):
     if not message:
         raise BadRequest("message is required")
 
+    existing_application = Application.query.filter_by(
+        user_id=user.id,
+        listing_id=listing.id,
+    ).first()
+    if existing_application is not None:
+        return jsonify({"error": "You have already applied to this listing."}), 409
+
     application = Application(user_id=user.id, listing_id=listing.id, message=message)
     db.session.add(application)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "You have already applied to this listing."}), 409
 
     return jsonify(application.to_dict()), 201

--- a/tests/test_listing_applications.py
+++ b/tests/test_listing_applications.py
@@ -1,0 +1,79 @@
+"""Tests for listing application submission behavior."""
+
+from __future__ import annotations
+
+from flask_jwt_extended import create_access_token
+
+from models import db
+from models.application import Application
+from models.listing import Listing
+from models.user import User
+
+
+def _auth_header(app, user_id: int) -> dict[str, str]:
+    with app.app_context():
+        token = create_access_token(identity=str(user_id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_worker_and_listing() -> tuple[int, int]:
+    employer = User(
+        email="employer-apps@example.com",
+        password_hash="hash",
+        role="employer",
+        is_verified=True,
+    )
+    worker = User(
+        email="worker-apps@example.com",
+        password_hash="hash",
+        role="worker",
+        is_verified=True,
+    )
+    db.session.add_all([employer, worker])
+    db.session.flush()
+
+    listing = Listing(
+        category="job",
+        title="Line Cook",
+        description="Kitchen role",
+        contact_method="email",
+        contact_value="jobs@example.com",
+        created_by=employer.id,
+        is_active=True,
+        is_public=True,
+    )
+    db.session.add(listing)
+    db.session.commit()
+
+    return worker.id, listing.id
+
+
+def test_apply_to_listing_returns_409_for_duplicate_application(app, client):
+    """Applying twice to the same listing should return a conflict response."""
+
+    with app.app_context():
+        worker_id, listing_id = _seed_worker_and_listing()
+
+    first_response = client.post(
+        f"/listings/{listing_id}/apply",
+        json={"message": "I am interested."},
+        headers=_auth_header(app, worker_id),
+    )
+    assert first_response.status_code == 201
+
+    duplicate_response = client.post(
+        f"/listings/{listing_id}/apply",
+        json={"message": "Applying again."},
+        headers=_auth_header(app, worker_id),
+    )
+
+    assert duplicate_response.status_code == 409
+    assert duplicate_response.get_json() == {
+        "error": "You have already applied to this listing."
+    }
+
+    with app.app_context():
+        assert (
+            Application.query.filter_by(user_id=worker_id, listing_id=listing_id).count()
+            == 1
+        )


### PR DESCRIPTION
### Motivation
- Prevent multiple applications from the same worker to the same listing by enforcing uniqueness at the DB level and surface a clear HTTP conflict when duplicates are attempted.
- Make the constraint safe to apply on existing databases by removing duplicates before altering the schema and protect against races on insert.

### Description
- Add a DB-level unique constraint to the `Application` model via `__table_args__` for `(user_id, listing_id)` in `models/application.py` (`uq_applications_user_id_listing_id`).
- Create an Alembic migration `migrations/versions/2f4c6b8a9d10_add_unique_constraint_on_applications.py` that deduplicates existing rows using a `ROW_NUMBER()` cleanup and then creates the unique constraint, and drops it on downgrade.
- Update `routes/listings.py` `apply_to_listing` to pre-check for an existing application and catch `IntegrityError` on commit, returning a user-friendly `409` JSON response when a duplicate application exists.
- Add `tests/test_listing_applications.py` to verify that applying twice returns `409` and only one application row exists.

### Testing
- Ran `pytest -q tests/test_listing_applications.py` and it passed (`1 passed`).
- The new migration was added at `migrations/versions/2f4c6b8a9d10_add_unique_constraint_on_applications.py` and model/route changes are in `models/application.py` and `routes/listings.py` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea30c3208333a1585a45e9ad7d36)