### PR TITLE
Harden document upload validation with MIME sniffing and safe local storage paths

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ class Config:
 
     Environment variables:
         MAX_UPLOAD_SIZE: Maximum upload size in bytes (default 10 MB).
-        ALLOWED_UPLOAD_TYPES: Comma-separated list of allowed MIME types for uploads.
+        ALLOWED_UPLOAD_RULES: Mapping of extension -> allowed MIME type(s) for uploads.
     """
 
     # Core
@@ -20,9 +20,16 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_DIR = os.getenv("UPLOAD_DIR", str(Path("workspace") / "uploads"))
     MAX_UPLOAD_SIZE = int(os.getenv("MAX_UPLOAD_SIZE", 10 * 1024 * 1024))
-    ALLOWED_UPLOAD_TYPES = os.getenv(
-        "ALLOWED_UPLOAD_TYPES", "image/jpeg,image/png,application/pdf"
-    ).split(",")
+    ALLOWED_UPLOAD_RULES = {
+        "pdf": ["application/pdf"],
+        "png": ["image/png"],
+        "jpg": ["image/jpeg"],
+        "jpeg": ["image/jpeg"],
+    }
+    # Backwards-compatible flattened MIME list consumed by older checks.
+    ALLOWED_UPLOAD_TYPES = sorted(
+        {mime for mimes in ALLOWED_UPLOAD_RULES.values() for mime in mimes}
+    )
 
     # CORS
     _raw_origins = os.getenv("ORIGINS", "*")

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -22,7 +22,18 @@ from utils.request_validation import parse_json_request
 verify_bp = Blueprint("verify", __name__)
 
 MAX_UPLOAD_SIZE_DEFAULT = 10 * 1024 * 1024  # 10 MB
-ALLOWED_EXTENSIONS_DEFAULT = {"jpeg", "jpg", "png", "pdf"}
+ALLOWED_UPLOAD_RULES_DEFAULT: dict[str, set[str]] = {
+    "pdf": {"application/pdf"},
+    "png": {"image/png"},
+    "jpg": {"image/jpeg"},
+    "jpeg": {"image/jpeg"},
+}
+
+
+_SIGNATURE_BYTES = {
+    "pdf": b"%PDF-",
+    "png": b"\x89PNG\r\n\x1a\n",
+}
 
 
 def _get_current_user() -> User | None:
@@ -67,35 +78,65 @@ def _parse_bool(value: object) -> bool | None:
     return None
 
 
-def _allowed_extensions() -> set[str]:
-    configured = current_app.config.get("ALLOWED_UPLOAD_TYPES")
-    if not configured:
-        return set(ALLOWED_EXTENSIONS_DEFAULT)
-    if isinstance(configured, str):
-        values: Iterable[str] = configured.split(",")
-    else:
-        values = configured
-    normalized = {
-        item.strip().lower().lstrip(".")
-        for item in values
-        if isinstance(item, str) and item.strip()
-    }
+def _get_allowed_upload_rules() -> dict[str, set[str]]:
+    configured = current_app.config.get("ALLOWED_UPLOAD_RULES")
+    normalized: dict[str, set[str]] = {}
+
+    if isinstance(configured, dict):
+        for extension, mimes in configured.items():
+            if not isinstance(extension, str):
+                continue
+            ext = extension.strip().lower().lstrip(".")
+            if not ext:
+                continue
+
+            if isinstance(mimes, str):
+                mime_values: Iterable[str] = [mimes]
+            elif isinstance(mimes, Iterable):
+                mime_values = mimes
+            else:
+                mime_values = []
+
+            parsed = {
+                mime.strip().lower()
+                for mime in mime_values
+                if isinstance(mime, str) and mime.strip()
+            }
+            if parsed:
+                normalized[ext] = parsed
+
     if not normalized:
-        return set(ALLOWED_EXTENSIONS_DEFAULT)
-    if "jpeg" in normalized:
-        normalized.add("jpg")
-    if "jpg" in normalized:
-        normalized.add("jpeg")
+        return {ext: set(mimes) for ext, mimes in ALLOWED_UPLOAD_RULES_DEFAULT.items()}
+
+    if "jpeg" in normalized and "jpg" not in normalized:
+        normalized["jpg"] = set(normalized["jpeg"])
+    if "jpg" in normalized and "jpeg" not in normalized:
+        normalized["jpeg"] = set(normalized["jpg"])
+
     return normalized
 
 
-def _validate_document(file: FileStorage) -> None:
+def _sniff_mime(header: bytes) -> str | None:
+    if header.startswith(_SIGNATURE_BYTES["pdf"]):
+        return "application/pdf"
+    if header.startswith(_SIGNATURE_BYTES["png"]):
+        return "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    return None
+
+
+def _validate_document(file: FileStorage) -> str:
     if file.filename is None or file.filename.strip() == "":
         raise BadRequest("A document file is required.")
 
+    if "." not in file.filename:
+        raise BadRequest("File must include a valid extension.")
+
+    allowed_rules = _get_allowed_upload_rules()
     extension = file.filename.rsplit(".", 1)[-1].lower()
-    if extension not in _allowed_extensions():
-        allowed = ", ".join(sorted(_allowed_extensions()))
+    if extension not in allowed_rules:
+        allowed = ", ".join(sorted(allowed_rules))
         raise BadRequest(f"File type not allowed. Allowed types: {allowed}.")
 
     max_size = int(current_app.config.get("MAX_UPLOAD_SIZE", MAX_UPLOAD_SIZE_DEFAULT))
@@ -104,6 +145,22 @@ def _validate_document(file: FileStorage) -> None:
     file.stream.seek(0)
     if size > max_size:
         raise BadRequest("File exceeds the maximum upload size of 10MB.")
+
+    header = file.stream.read(16)
+    file.stream.seek(0)
+    sniffed_mime = _sniff_mime(header)
+    if sniffed_mime is None:
+        raise BadRequest("Unsupported or suspicious file content.")
+
+    allowed_mimes = allowed_rules[extension]
+    if sniffed_mime not in allowed_mimes:
+        raise BadRequest("File content does not match the file extension.")
+
+    declared_mime = (file.mimetype or "").lower().strip()
+    if declared_mime and declared_mime not in allowed_mimes:
+        raise BadRequest("Uploaded MIME type does not match the file extension.")
+
+    return sniffed_mime
 
 
 def _build_unique_filename(original: str) -> str:
@@ -136,7 +193,7 @@ def upload_document():
     if not isinstance(file, FileStorage):
         raise BadRequest("A document file is required.")
 
-    _validate_document(file)
+    sniffed_mime = _validate_document(file)
 
     waiver_value = _parse_bool(request.form.get("waiver"))
     if waiver_value is None:
@@ -150,7 +207,7 @@ def upload_document():
         user_id=user.id,
         filename=file.filename or stored_filename,
         file_path=stored_path,
-        file_type=file.mimetype or "application/octet-stream",
+        file_type=sniffed_mime,
         waiver_acknowledged=waiver_value,
         status="pending",
     )

--- a/storage/local_storage.py
+++ b/storage/local_storage.py
@@ -17,8 +17,14 @@ class LocalStorage(AbstractStorage):
     """Persist files to the local filesystem under the configured upload directory."""
 
     def __init__(self, upload_dir: str | None = None):
-        self.base_directory = Path(upload_dir or Config.UPLOAD_DIR)
+        self.base_directory = Path(upload_dir or Config.UPLOAD_DIR).resolve()
         os.makedirs(self.base_directory, exist_ok=True)
+
+    def _resolve_relative_path(self, path: str) -> Path:
+        candidate = (self.base_directory / path).resolve()
+        if self.base_directory not in candidate.parents and candidate != self.base_directory:
+            raise ValueError("Path must remain within the upload directory.")
+        return candidate
 
     def save(self, file_obj: IO[bytes], filename: str) -> str:
         """Save a file and return the relative path within the upload directory."""
@@ -27,7 +33,7 @@ class LocalStorage(AbstractStorage):
         if not safe_name:
             raise ValueError("Filename must contain at least one valid character.")
 
-        destination = self.base_directory / safe_name
+        destination = self._resolve_relative_path(safe_name)
         if hasattr(file_obj, "save"):
             file_obj.save(destination)  # type: ignore[arg-type]
         else:
@@ -39,9 +45,12 @@ class LocalStorage(AbstractStorage):
     def exists(self, path: str) -> bool:
         """Return True if the given relative path exists within the upload directory."""
 
-        return (self.base_directory / path).exists()
+        try:
+            return self._resolve_relative_path(path).exists()
+        except ValueError:
+            return False
 
     def open(self, path: str, mode: str = "rb") -> BinaryIO:
         """Open a stored file using the provided mode."""
 
-        return open(self.base_directory / path, mode)
+        return open(self._resolve_relative_path(path), mode)

--- a/tests/test_verify_flow.py
+++ b/tests/test_verify_flow.py
@@ -64,7 +64,7 @@ def test_upload_and_status(app: Flask, client):
     upload_response = client.post(
         "/verify/upload",
         data={
-            "document": (BytesIO(b"PDF data"), "document.pdf"),
+            "document": (BytesIO(b"%PDF-1.7\n"), "document.pdf"),
             "waiver": "true",
         },
         headers=headers,

--- a/tests/test_verify_routes.py
+++ b/tests/test_verify_routes.py
@@ -34,7 +34,7 @@ def test_upload_document_creates_pending_record(app, client):
         user_id = user.id
 
     data = {
-        "document": (BytesIO(b"PDF data"), "visa.pdf"),
+        "document": (BytesIO(b"%PDF-1.7\n"), "visa.pdf"),
         "waiver": "true",
     }
 
@@ -58,6 +58,53 @@ def test_upload_document_creates_pending_record(app, client):
     assert document.waiver_acknowledged is True
     stored_file = Path(app.config["UPLOAD_DIR"]) / document.file_path
     assert stored_file.exists()
+
+
+def test_upload_document_rejects_disallowed_extension(app, client):
+    """Uploading a file with an unsupported extension returns 400."""
+
+    with app.app_context():
+        user = _create_user("blocked-ext@example.com")
+        user_id = user.id
+
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(b"MZ\x00\x02"), "malware.exe"),
+            "waiver": "true",
+        },
+        headers=_auth_headers(app, user_id),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Bad Request"
+    assert "File type not allowed" in payload["detail"]
+
+
+def test_upload_document_rejects_spoofed_content(app, client):
+    """Uploading a mismatched extension/content pair is rejected."""
+
+    with app.app_context():
+        user = _create_user("spoofed@example.com")
+        user_id = user.id
+
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"data"
+    response = client.post(
+        "/verify/upload",
+        data={
+            "document": (BytesIO(png_bytes), "identity.pdf", "application/pdf"),
+            "waiver": "true",
+        },
+        headers=_auth_headers(app, user_id),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Bad Request"
+    assert "does not match the file extension" in payload["detail"]
 
 
 def test_status_endpoint_returns_latest_document(app, client):


### PR DESCRIPTION
### Motivation
- Centralize allowed upload rules and make extension↔MIME mapping explicit so policy is easy to review and override.
- Reject files whose content does not match their extension to reduce spoofed or malicious uploads.
- Ensure local storage path handling stays strictly inside the configured upload directory to prevent path traversal or accidental exposure.

### Description
- Add `ALLOWED_UPLOAD_RULES` (extension → MIME list) and a backwards-compatible `ALLOWED_UPLOAD_TYPES` flattening in `config.py` to centralize upload rules.
- Implement `_get_allowed_upload_rules`, `_sniff_mime`, and stricter `_validate_document` in `routes/verify.py` to enforce extension presence, max-size checks, signature-based MIME sniffing (PDF/PNG/JPEG), declared-MIME matching, and to return the sniffed MIME for persistence.
- Use the sniffed MIME when creating `VisaDocument` records in `routes/verify.py` so stored metadata reflects inspected content.
- Harden `LocalStorage` in `storage/local_storage.py` by resolving `base_directory` and adding `_resolve_relative_path` used by `save`, `exists`, and `open` to guarantee all file operations remain within the upload root.
- Add tests in `tests/test_verify_routes.py` that assert disallowed extensions and spoofed extension/content pairs are rejected, and update upload fixtures in `tests/test_verify_flow.py`/`tests/test_verify_routes.py` to include valid PDF signature bytes for the stricter validation.

### Testing
- Ran the verification tests with `pytest -q tests/test_verify_routes.py tests/test_verify_flow.py` and all tests passed.
- Existing verification and flow tests were updated and executed to validate positive and negative upload scenarios.
- No database migrations were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea3287c0833388a420d3147404fa)