### PR TITLE
Add pagination to listings and admin pending verification endpoints

### DIFF
--- a/routes/listings.py
+++ b/routes/listings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from math import ceil
 
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import (
@@ -22,6 +23,10 @@ from models.user import User
 from utils.request_validation import parse_json_request
 
 listings_bp = Blueprint("listings", __name__)
+
+DEFAULT_PAGE = 1
+DEFAULT_PER_PAGE = 20
+MAX_PER_PAGE = 100
 
 
 def _get_current_user(optional: bool = False) -> User | None:
@@ -75,6 +80,24 @@ def _parse_bool(value):
     return None
 
 
+def _parse_pagination_params() -> tuple[int, int]:
+    page_raw = request.args.get("page", str(DEFAULT_PAGE))
+    per_page_raw = request.args.get("per_page", str(DEFAULT_PER_PAGE))
+
+    try:
+        page = int(page_raw)
+        per_page = int(per_page_raw)
+    except (TypeError, ValueError):
+        raise BadRequest("page and per_page must be integers.") from None
+
+    if page < 1:
+        raise BadRequest("page must be greater than 0.")
+    if per_page < 1:
+        raise BadRequest("per_page must be greater than 0.")
+
+    return page, min(per_page, MAX_PER_PAGE)
+
+
 @listings_bp.route("", methods=["GET"])
 def search_listings():
     """Return listings with optional filters."""
@@ -119,15 +142,38 @@ def search_listings():
             )
         )
 
-    listings = query.order_by(Listing.created_at.desc()).all()
+    page, per_page = _parse_pagination_params()
 
-    payload = []
+    listings = query.order_by(Listing.created_at.desc(), Listing.id.desc()).all()
+
+    visible_listings = []
     for listing in listings:
         if not _can_view_listing(listing, user):
             continue
-        payload.append(listing.to_dict(include_contact=_can_view_contact(listing, user)))
+        visible_listings.append(
+            listing.to_dict(include_contact=_can_view_contact(listing, user))
+        )
 
-    return jsonify({"results": payload, "count": len(payload)})
+    total = len(visible_listings)
+    start = (page - 1) * per_page
+    end = start + per_page
+    page_results = visible_listings[start:end]
+    total_pages = ceil(total / per_page) if total else 0
+
+    return jsonify(
+        {
+            "results": page_results,
+            "count": len(page_results),
+            "pagination": {
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    )
 
 
 def _validate_listing_payload(data: dict, partial: bool = False):

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from math import ceil
 from pathlib import Path
 from typing import Iterable
 
@@ -23,6 +24,9 @@ verify_bp = Blueprint("verify", __name__)
 
 MAX_UPLOAD_SIZE_DEFAULT = 10 * 1024 * 1024  # 10 MB
 ALLOWED_EXTENSIONS_DEFAULT = {"jpeg", "jpg", "png", "pdf"}
+DEFAULT_PAGE = 1
+DEFAULT_PER_PAGE = 20
+MAX_PER_PAGE = 100
 
 
 def _get_current_user() -> User | None:
@@ -67,6 +71,24 @@ def _parse_bool(value: object) -> bool | None:
     return None
 
 
+def _parse_pagination_params() -> tuple[int, int]:
+    page_raw = request.args.get("page", str(DEFAULT_PAGE))
+    per_page_raw = request.args.get("per_page", str(DEFAULT_PER_PAGE))
+
+    try:
+        page = int(page_raw)
+        per_page = int(per_page_raw)
+    except (TypeError, ValueError):
+        raise BadRequest("page and per_page must be integers.") from None
+
+    if page < 1:
+        raise BadRequest("page must be greater than 0.")
+    if per_page < 1:
+        raise BadRequest("per_page must be greater than 0.")
+
+    return page, min(per_page, MAX_PER_PAGE)
+
+
 def _allowed_extensions() -> set[str]:
     configured = current_app.config.get("ALLOWED_UPLOAD_TYPES")
     if not configured:
@@ -79,6 +101,9 @@ def _allowed_extensions() -> set[str]:
         item.strip().lower().lstrip(".")
         for item in values
         if isinstance(item, str) and item.strip()
+    }
+    normalized = {
+        item.split("/", 1)[1] if "/" in item else item for item in normalized
     }
     if not normalized:
         return set(ALLOWED_EXTENSIONS_DEFAULT)
@@ -218,13 +243,36 @@ def list_pending_documents() -> ResponseReturnValue:
 
     _require_admin()
 
+    page, per_page = _parse_pagination_params()
+
     pending_documents = (
         VisaDocument.query.filter_by(status="pending")
-        .order_by(VisaDocument.created_at.asc())
+        .order_by(VisaDocument.created_at.asc(), VisaDocument.id.asc())
         .all()
     )
 
-    return jsonify([_serialize_pending_document(document) for document in pending_documents])
+    total = len(pending_documents)
+    start = (page - 1) * per_page
+    end = start + per_page
+    page_results = pending_documents[start:end]
+    total_pages = ceil(total / per_page) if total else 0
+
+    return jsonify(
+        {
+            "results": [
+                _serialize_pending_document(document) for document in page_results
+            ],
+            "count": len(page_results),
+            "pagination": {
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    )
 
 
 @verify_bp.record_once

--- a/tests/test_listings_billing.py
+++ b/tests/test_listings_billing.py
@@ -96,3 +96,75 @@ def test_listing_creation_allows_active_subscription(app, client):
         subscription = EmployerSubscription.query.filter_by(user_id=user_id).first()
         assert subscription.listing_credits == 0
         assert Listing.query.count() == 1
+
+
+def test_search_listings_supports_pagination_metadata(app, client):
+    """Search listings returns paginated results with metadata."""
+
+    with app.app_context():
+        creator_id = _create_employer("paging@example.com")
+        now = datetime.utcnow()
+        listings = [
+            Listing(
+                category="job",
+                title=f"Role {index}",
+                description="desc",
+                contact_method="email",
+                contact_value="contact@example.com",
+                is_public=True,
+                is_active=True,
+                created_by=creator_id,
+                created_at=now + timedelta(seconds=index),
+            )
+            for index in range(5)
+        ]
+        db.session.add_all(listings)
+        db.session.commit()
+
+    response = client.get("/listings?page=2&per_page=2")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["count"] == 2
+    assert [item["title"] for item in payload["results"]] == ["Role 2", "Role 1"]
+    assert payload["pagination"] == {
+        "page": 2,
+        "per_page": 2,
+        "total": 5,
+        "total_pages": 3,
+        "has_next": True,
+        "has_prev": True,
+    }
+
+
+def test_search_listings_per_page_is_capped(app, client):
+    """Search listings caps per_page at the route maximum."""
+
+    with app.app_context():
+        creator_id = _create_employer("paging-cap@example.com")
+        now = datetime.utcnow()
+        listings = [
+            Listing(
+                category="job",
+                title=f"Cap Role {index}",
+                description="desc",
+                contact_method="email",
+                contact_value="contact@example.com",
+                is_public=True,
+                is_active=True,
+                created_by=creator_id,
+                created_at=now + timedelta(seconds=index),
+            )
+            for index in range(101)
+        ]
+        db.session.add_all(listings)
+        db.session.commit()
+
+    response = client.get("/listings?page=1&per_page=1000")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["count"] == 100
+    assert payload["pagination"]["per_page"] == 100
+    assert payload["pagination"]["total"] == 101
+    assert payload["pagination"]["total_pages"] == 2

--- a/tests/test_verify_routes.py
+++ b/tests/test_verify_routes.py
@@ -149,14 +149,76 @@ def test_admin_list_pending_documents_returns_only_pending(app, client):
 
     assert response.status_code == 200
     payload = response.get_json()
-    assert isinstance(payload, list)
-    assert [item["id"] for item in payload] == [pending_old_id, pending_new_id]
-    for item in payload:
+    assert payload["count"] == 2
+    assert payload["pagination"] == {
+        "page": 1,
+        "per_page": 20,
+        "total": 2,
+        "total_pages": 1,
+        "has_next": False,
+        "has_prev": False,
+    }
+    assert [item["id"] for item in payload["results"]] == [pending_old_id, pending_new_id]
+    for item in payload["results"]:
         assert set(item.keys()) == {"id", "user_id", "filename", "created_at"}
         assert item["created_at"] is not None
         # Ensure ISO-8601 parseable string
         parsed = datetime.fromisoformat(item["created_at"])
         assert isinstance(parsed, datetime)
+
+
+def test_admin_list_pending_documents_pagination_and_limit_cap(app, client):
+    """Admin pending list supports paging and caps per_page to max."""
+
+    with app.app_context():
+        admin = _create_user("admin-paging@example.com", role="admin")
+        worker = _create_user("pending-paging@example.com")
+        base_time = datetime.utcnow() - timedelta(days=1)
+        documents = [
+            VisaDocument(
+                user_id=worker.id,
+                filename=f"doc-{index}.pdf",
+                file_path=f"doc-{index}.pdf",
+                file_type="application/pdf",
+                status="pending",
+                waiver_acknowledged=True,
+                created_at=base_time + timedelta(minutes=index),
+            )
+            for index in range(101)
+        ]
+        db.session.add_all(documents)
+        db.session.commit()
+        admin_id = admin.id
+
+    page_two_response = client.get(
+        "/admin/verify/pending?page=2&per_page=2",
+        headers=_auth_headers(app, admin_id),
+    )
+    assert page_two_response.status_code == 200
+    page_two_payload = page_two_response.get_json()
+    assert page_two_payload["count"] == 2
+    assert [item["filename"] for item in page_two_payload["results"]] == [
+        "doc-2.pdf",
+        "doc-3.pdf",
+    ]
+    assert page_two_payload["pagination"] == {
+        "page": 2,
+        "per_page": 2,
+        "total": 101,
+        "total_pages": 51,
+        "has_next": True,
+        "has_prev": True,
+    }
+
+    capped_response = client.get(
+        "/admin/verify/pending?page=1&per_page=1000",
+        headers=_auth_headers(app, admin_id),
+    )
+    assert capped_response.status_code == 200
+    capped_payload = capped_response.get_json()
+    assert capped_payload["count"] == 100
+    assert capped_payload["pagination"]["per_page"] == 100
+    assert capped_payload["pagination"]["total_pages"] == 2
 
 
 def test_admin_can_download_document(app, client):


### PR DESCRIPTION
### Motivation
- Provide paginated listing results with sane defaults and caps so clients can page through search results.
- Make admin pending-document listing deterministic and pageable to support UI review flows and limit-heavy queries.
- Ensure upload type normalization still accepts MIME-style config values used in test environments.

### Description
- Added `page`/`per_page` parsing and validation with `DEFAULT_PAGE=1`, `DEFAULT_PER_PAGE=20`, and `MAX_PER_PAGE=100` and a shared `_parse_pagination_params()` helper in `routes/listings.py` and `routes/verify.py`.
- Updated `search_listings` to order deterministically (`created_at DESC, id DESC`), filter visible listings, slice results for the requested page, and return `results`, `count`, and `pagination` metadata (`page`, `per_page`, `total`, `total_pages`, `has_next`, `has_prev`).
- Updated `list_pending_documents` to apply deterministic ordering (`created_at ASC, id ASC`), page slicing, and the same pagination metadata shape.
- Normalized configured upload types in `routes/verify.py` so MIME-type values (e.g. `application/pdf`) are converted to extensions for filename extension validation.
- Added/updated tests in `tests/test_listings_billing.py` and `tests/test_verify_routes.py` to assert pagination metadata, deterministic ordering, and enforcement of the `per_page` cap.

### Testing
- Ran `pytest tests/test_listings_billing.py tests/test_verify_routes.py -q` and the modified tests passed (all tests green).
- The changes were exercised by new tests that cover page slicing, metadata correctness, deterministic order, and per-page cap enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea35187083339c1ffa0cbb82fdff)